### PR TITLE
Early network event crash fix

### DIFF
--- a/Source/FicsItNetworks/Network/FINNetworkTrace.cpp
+++ b/Source/FicsItNetworks/Network/FINNetworkTrace.cpp
@@ -320,7 +320,9 @@ Step(UFGPowerConnectionComponent, UFGPowerInfoComponent, {
 })
 
 Step(UFINNetworkComponent, UFINNetworkComponent, {
-	return IFINNetworkCircuitNode::Execute_GetCircuit(oA)->HasNode(oB);
+	auto circuit = IFINNetworkCircuitNode::Execute_GetCircuit(oA);
+	if(circuit == nullptr) return false;
+	return circuit->HasNode(oB);
 })
 
 Step(UFINNetworkComponent, AFINNetworkCircuit, {


### PR DESCRIPTION
When an event gets sent early in the world loading phase(first player join chat message), the game crashes because GetCircuit returns null.