### PR TITLE
Temporary fix for the crash on load issue reported in discord

### DIFF
--- a/Source/FicsItNetworks/Private/FicsItKernel/FicsItFS/FileSystem.cpp
+++ b/Source/FicsItNetworks/Private/FicsItKernel/FicsItFS/FileSystem.cpp
@@ -82,11 +82,12 @@ CodersFileSystem::Path FFINKernelFSRoot::unpersistPath(std::string path) {
 	CodersFileSystem::SRef<CodersFileSystem::Device> dev;
 	if (pos == 0) {
 		dev = devDev;
-    } else for (std::pair<const std::string, CodersFileSystem::SRef<CodersFileSystem::Device>>& device : devDev->getDevices()) {
+    } else if(devDev.isValid()) for (std::pair<const std::string, CodersFileSystem::SRef<CodersFileSystem::Device>>& device : devDev->getDevices()) {
 		if (device.first == name) {
 			dev = device.second;
 			break;
 		}
+    	throw std::invalid_argument("Invalid mount point. Unable to persist path");
 	}
 	if (dev.isValid()) for (auto& mount : mounts) {
 		if (mount.second.first == dev) {


### PR DESCRIPTION
This fix is subject to change once pana gets to making a proper fix. The error allegedly occur because the game does not properly save which device is mounted. This adds a safe-guard that crashes the lua machine instead of the game.
