### PR TITLE
Adding FINGenLuaDocSumneko Command

### DIFF
--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDoc.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDoc.cpp
@@ -91,7 +91,7 @@ void FINGenLuaClass(FString& Documentation, FFINReflection& Ref, UFINClass* Clas
 	FINGenLuaDescription(Documentation,  Class->GetDescription().ToString());
 	Documentation.Append(FString::Printf(TEXT("---@class %s%s\n"), *Class->GetInternalName(), Class->GetParent() ? *(TEXT(":") + Class->GetParent()->GetInternalName()) : TEXT("")));
 	for (UFINProperty* Prop : Class->GetProperties(false)) {
-		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) FINGenLuaProperty(Documentation, Ref, Prop);
+		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib)	FINGenLuaProperty(Documentation, Ref, Prop);
 	}
 	Documentation.Append(FString::Printf(TEXT("local %s\n"), *Class->GetInternalName()));
 	for (UFINFunction* Func : Class->GetFunctions(false)) {
@@ -104,7 +104,7 @@ void FINGenLuaStruct(FString& Documentation, FFINReflection& Ref, UFINStruct* St
 	FINGenLuaDescription(Documentation, Struct->GetDescription().ToString());
 	Documentation.Append(FString::Printf(TEXT("---@class %s\n"), *Struct->GetInternalName()));
 	for (UFINProperty* Prop : Struct->GetProperties(false)) {
-		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) FINGenLuaProperty(Documentation, Ref, Prop);
+		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib)	FINGenLuaProperty(Documentation, Ref, Prop);
 	}
 	Documentation.Append(FString::Printf(TEXT("local %s\n"), *Struct->GetInternalName()));
 	for (UFINFunction* Func : Struct->GetFunctions(false)) {

--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
@@ -381,7 +381,7 @@ FString FINGenLuaSumnekoClass(FFINReflection &Ref, const UFINClass *Class) {
 
 	FINGenLuaSumnekoDescription(ClassDocumentation, Class->GetDescription().ToString());
 	ClassDocumentation.Append(FString::Printf(
-		TEXT("\n---@class %s%s%s\n"),
+		TEXT("---@class %s%s%s\n"),
 		*FINGenLuaSumnekoGetTypeName(Class),
 		*(Class->GetParent()
 			  ? TEXT(" : ") + FINGenLuaSumnekoGetTypeName(Class->GetParent())
@@ -413,7 +413,7 @@ FString FINGenLuaSumnekoStruct(FFINReflection &Ref, const UFINStruct *Struct) {
 			MembersDocumentation.Append(FINGenLuaSumnekoFunction(Ref, Struct->GetInternalName(), Func));
 		}
 	}
-
+	
 	FString StructDocumentation = "\n";
 	FINGenLuaSumnekoDescription(StructDocumentation, Struct->GetDescription().ToString());
 	StructDocumentation.Append(FString::Printf(

--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
@@ -200,7 +200,7 @@ FString FINGenLuaSumnekoOperator(FFINReflection &Ref, const UFINFunction *Op) {
 
 	else {
 		// this is not the best way to handle the issue but will get reported on github
-		throw new FFINException(TEXT("unsupported FIN_Operator: ") + OpName);
+		throw new FFINException(TEXT("trying to map unsupported FIN_Operator: ") + OpName + TEXT(" to sumneko operator annotation"));
 	}
 
 	FString OpParameter;

--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
@@ -1,5 +1,7 @@
 ﻿#include "Utils/FINGenLuaDocSumneko.h"
 
+#include "Misc/App.h"
+#include "Misc/FileHelper.h"
 #include "Reflection/FINArrayProperty.h"
 #include "Reflection/FINClassProperty.h"
 #include "Reflection/FINObjectProperty.h"
@@ -15,7 +17,6 @@ FString FINGenLuaGetTypeNameSumneko(const UFINBase *Base) {
 
 	FString BasePackageName;
 	for (auto BasePackageNamePart : SplitBasePackageName) {
-
 		// get rid of unnecessary names
 		if (BasePackageNamePart.Equals(TEXT("Script"))
 			|| BasePackageNamePart.Equals(TEXT("Game"))
@@ -39,51 +40,55 @@ FString FINGenLuaGetTypeNameSumneko(const UFINBase *Base) {
 	return BasePackageName + Base->GetInternalName();
 }
 
-FString FINGenLuaGetTypeSumneko(FFINReflection& Ref, const UFINProperty* Prop) {
+FString FINGenLuaGetTypeSumneko(FFINReflection &Ref, const UFINProperty *Prop) {
 	if (!Prop) {
 		return "any";
 	}
-	
+
 	switch (Prop->GetType()) {
-		case FIN_NIL:
-			return "nil";
-		case FIN_BOOL:
-			return "boolean";
-		case FIN_INT:
-		case FIN_FLOAT:
-			return "number";
-		case FIN_STR:
-			return "string";
-		case FIN_OBJ: {
-			const UFINObjectProperty* ObjProp = Cast<UFINObjectProperty>(Prop);
-			const UFINClass* Class = Ref.FindClass(ObjProp->GetSubclass());
-			if (!Class) return "Object";
-			return FINGenLuaGetTypeNameSumneko(Class);
-		}
-		case FIN_TRACE: {
-			const UFINTraceProperty* TraceProp = Cast<UFINTraceProperty>(Prop);
-			const UFINClass* Class = Ref.FindClass(TraceProp->GetSubclass());
-			if (!Class) return "Object";
-			return FINGenLuaGetTypeNameSumneko(Class);
-		}
-		case FIN_CLASS: {
-			const UFINClassProperty* ClassProp = Cast<UFINClassProperty>(Prop);
-			const UFINClass* Class = Ref.FindClass(ClassProp->GetSubclass());
-			if (!Class) return "Object";
-			return FINGenLuaGetTypeNameSumneko(Class);
-		}
-		case FIN_STRUCT: {
-			const UFINStructProperty* StructProp = Cast<UFINStructProperty>(Prop);
-			const UFINStruct* Struct = Ref.FindStruct(StructProp->GetInner());
-			if (!Struct) return "any";
-			return FINGenLuaGetTypeNameSumneko(Struct);
-		}
-		case FIN_ARRAY: {
-			const UFINArrayProperty* ArrayProp = Cast<UFINArrayProperty>(Prop);
-			return FINGenLuaGetTypeSumneko(Ref, ArrayProp->GetInnerType()) + "[]";
-		}
-		default:
+	case FIN_NIL:
+		return "nil";
+	case FIN_BOOL:
+		return "boolean";
+	case FIN_INT:
+	case FIN_FLOAT:
+		return "number";
+	case FIN_STR:
+		return "string";
+	case FIN_OBJ: {
+		const UFINObjectProperty *ObjProp = Cast<UFINObjectProperty>(Prop);
+		const UFINClass *Class = Ref.FindClass(ObjProp->GetSubclass());
+		if (!Class)
+			return "Object";
+		return FINGenLuaGetTypeNameSumneko(Class);
+	}
+	case FIN_TRACE: {
+		const UFINTraceProperty *TraceProp = Cast<UFINTraceProperty>(Prop);
+		const UFINClass *Class = Ref.FindClass(TraceProp->GetSubclass());
+		if (!Class)
+			return "Object";
+		return FINGenLuaGetTypeNameSumneko(Class);
+	}
+	case FIN_CLASS: {
+		const UFINClassProperty *ClassProp = Cast<UFINClassProperty>(Prop);
+		const UFINClass *Class = Ref.FindClass(ClassProp->GetSubclass());
+		if (!Class)
+			return "Object";
+		return FINGenLuaGetTypeNameSumneko(Class);
+	}
+	case FIN_STRUCT: {
+		const UFINStructProperty *StructProp = Cast<UFINStructProperty>(Prop);
+		const UFINStruct *Struct = Ref.FindStruct(StructProp->GetInner());
+		if (!Struct)
 			return "any";
+		return FINGenLuaGetTypeNameSumneko(Struct);
+	}
+	case FIN_ARRAY: {
+		const UFINArrayProperty *ArrayProp = Cast<UFINArrayProperty>(Prop);
+		return FINGenLuaGetTypeSumneko(Ref, ArrayProp->GetInnerType()) + "[]";
+	}
+	default:
+		return "any";
 	}
 }
 
@@ -93,7 +98,7 @@ FString FormatDescription(FString Description) {
 	return Description;
 }
 
-void FINGenLuaDescriptionSumneko(FString& Documentation, FString Description) {
+void FINGenLuaDescriptionSumneko(FString &Documentation, FString Description) {
 	Description.ReplaceInline(TEXT("\r\n"), TEXT("\n"));
 
 	FString Line;
@@ -103,100 +108,121 @@ void FINGenLuaDescriptionSumneko(FString& Documentation, FString Description) {
 	Documentation.Append(TEXT("--- ") + Description + TEXT("\n"));
 }
 
-void FINGenLuaPropertySumneko(FString& Documentation, FFINReflection& Ref, const FString& Parent, const UFINProperty* Prop) {
+void FINGenLuaPropertySumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
+                              const UFINProperty *Prop) {
 	Documentation.Append(TEXT("\n"));
-	
+
 	const EFINRepPropertyFlags PropFlags = Prop->GetPropertyFlags();
 	FINGenLuaDescriptionSumneko(Documentation, TEXT("### Flags:"));
-	
+
 	if (PropFlags & FIN_Prop_RT_Sync) {
 		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
 	}
-	
+
 	if (PropFlags & FIN_Prop_RT_Parallel) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
+		FINGenLuaDescriptionSumneko(Documentation,
+		                            TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
 	}
-	
+
 	if (PropFlags & FIN_Prop_RT_Async) {
 		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
 	}
-	
+
 	if (PropFlags & FIN_Prop_ReadOnly) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Read Only - The value of this property can not be changed by code."));
+		FINGenLuaDescriptionSumneko(Documentation,
+		                            TEXT("* Read Only - The value of this property can not be changed by code."));
 	}
 
 	Documentation.Append(FString::Printf(TEXT("---@type %s\n"), *FINGenLuaGetTypeSumneko(Ref, Prop)));
 	Documentation.Append(FString::Printf(TEXT("%s.%s = nil\n"), *Parent, *Prop->GetInternalName()));
 }
 
-void FINGenLuaFunctionSumneko(FString& Documentation, FFINReflection& Ref, const FString& Parent, const UFINFunction* Func) {
+void FINGenLuaFunctionSumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
+                              const UFINFunction *Func) {
 	Documentation.Append(TEXT("\n"));
-	
+
 	FINGenLuaDescriptionSumneko(Documentation, Func->GetDescription().ToString());
 
 	const EFINFunctionFlags funcFlags = Func->GetFunctionFlags();
 	FINGenLuaDescriptionSumneko(Documentation, TEXT("### Flags:"));
-	
+
 	if (funcFlags & FIN_Func_RT_Sync) {
 		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
 	}
-	
+
 	if (funcFlags & FIN_Func_RT_Parallel) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
+		FINGenLuaDescriptionSumneko(Documentation,
+		                            TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
 	}
-	
+
 	if (funcFlags & FIN_Func_RT_Async) {
 		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
 	}
-	
+
 	if (funcFlags & FIN_Func_VarArgs) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Variable Arguments - Can have any additional arguments as described."));
+		FINGenLuaDescriptionSumneko(Documentation,
+		                            TEXT("* Variable Arguments - Can have any additional arguments as described."));
 	}
 
 	FString ReturnValues;
 	FString ParamList;
-	for (const UFINProperty* Prop : Func->GetParameters()) {
+	for (const UFINProperty *Prop : Func->GetParameters()) {
 		const EFINRepPropertyFlags Flags = Prop->GetPropertyFlags();
 
 		if (!(Flags & FIN_Prop_Param)) {
 			continue;
 		}
-		
+
 		if (Flags & FIN_Prop_OutParam) {
 			if (ReturnValues.Len() > 0) {
 				ReturnValues.Append(",");
 			}
-			
+
 			ReturnValues.Append(*FINGenLuaGetTypeSumneko(Ref, Prop));
-		}
-		else {
+		} else {
 			Documentation.Append(FString::Printf(
 				TEXT("---@param %s %s @%s\n"),
 				*Prop->GetInternalName(),
 				*FINGenLuaGetTypeSumneko(Ref, Prop),
 				*FormatDescription(Prop->GetDescription().ToString())
 			));
-			
+
 			if (ParamList.Len() > 0) {
 				ParamList.Append(", ");
 			}
-			
+
 			ParamList.Append(Prop->GetInternalName());
 		}
 	}
-	if (ReturnValues.Len() > 0) Documentation.Append(FString::Printf(TEXT("---@return %s\n"), *ReturnValues));
-	Documentation.Append(FString::Printf(TEXT("function %s:%s(%s) end\n"), *Parent, *Func->GetInternalName(), *ParamList));
+
+	if (funcFlags & FIN_Func_VarArgs) {
+		Documentation.Append(TEXT("---@param ... any @additional arguments as described"));
+
+		if (ParamList.Len() > 0) {
+			ParamList.Append(", ");
+		}
+
+		ParamList.Append("...");
+	}
+
+	if (ReturnValues.Len() > 0) {
+		Documentation.Append(FString::Printf(TEXT("---@return %s\n"), *ReturnValues));
+	}
+
+	Documentation.Append(
+		FString::Printf(TEXT("function %s:%s(%s) end\n"), *Parent, *Func->GetInternalName(), *ParamList));
 }
 
-void FINGenLuaSignalSumneko(FString& Documentation, FFINReflection& Ref, const FString& Parent, const UFINSignal* Signal) {
+void FINGenLuaSignalSumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
+                            const UFINSignal *Signal) {
 	Documentation.Append(TEXT("\n"));
-	
+
 	FINGenLuaDescriptionSumneko(Documentation, Signal->GetDescription().ToString() + TEXT("\n"));
 
 	FINGenLuaDescriptionSumneko(Documentation, TEXT("### returns from event.pull:\n```"));
 
 	Documentation.Append(TEXT("--- local signalName, component"));
-	for (const UFINProperty* Prop : Signal->GetParameters()) {
+	for (const UFINProperty *Prop : Signal->GetParameters()) {
 		Documentation.Append(TEXT(", ") + Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")));
 	}
 	if (Signal->IsVarArgs()) {
@@ -204,58 +230,63 @@ void FINGenLuaSignalSumneko(FString& Documentation, FFINReflection& Ref, const F
 	}
 	Documentation.Append(TEXT(" = event.pull()\n--- ```\n"));
 
-	FINGenLuaDescriptionSumneko(Documentation, FString::Printf(TEXT("- `signalName: \"%s\"`"), *Signal->GetInternalName()));
+	FINGenLuaDescriptionSumneko(Documentation,
+	                            FString::Printf(TEXT("- `signalName: \"%s\"`"), *Signal->GetInternalName()));
 	FINGenLuaDescriptionSumneko(Documentation, FString::Printf(TEXT("- `component: %s`"), *Parent));
-	
-	for (const UFINProperty* Prop : Signal->GetParameters()) {
+
+	for (const UFINProperty *Prop : Signal->GetParameters()) {
 		FINGenLuaDescriptionSumneko(Documentation, FString::Printf(
-			TEXT("- `%s: %s` \n%s"),
-			*Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")),
-			*FINGenLuaGetTypeSumneko(Ref, Prop),
-			*Prop->GetDescription().ToString()
-		));
+			                            TEXT("- `%s: %s` \n%s"),
+			                            *Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")),
+			                            *FINGenLuaGetTypeSumneko(Ref, Prop),
+			                            *Prop->GetDescription().ToString()
+		                            ));
 	}
 
 	// hard coding the type is maybe not the best choice
-	Documentation.Append(TEXT("---@deprecated\n---@type FIN.Signal\n")); //TODO: keep up to date
+	Documentation.Append(TEXT("---@deprecated\n---@type FIN.Signal\n"));
 	Documentation.Append(FString::Printf(
 		TEXT("%s.%s = { isVarArgs = %s }\n"),
 		*Parent,
 		*Signal->GetInternalName(),
-		Signal->IsVarArgs() ? TEXT("true") : TEXT("false")
+		Signal->IsVarArgs()
+			? TEXT("true")
+			: TEXT("false")
 	));
 }
 
-void FINGenLuaClassSumneko(FString& Documentation, FFINReflection& Ref, const UFINClass* Class) {
+void FINGenLuaClassSumneko(FString &Documentation, FFINReflection &Ref, const UFINClass *Class) {
 	Documentation.Append(TEXT("\n"));
-	
+
 	FINGenLuaDescriptionSumneko(Documentation, Class->GetDescription().ToString());
 	Documentation.Append(FString::Printf(
 		TEXT("---@class %s%s\nlocal %s\n"),
 		*FINGenLuaGetTypeNameSumneko(Class),
-		Class->GetParent() ? *(TEXT(" : ") + FINGenLuaGetTypeNameSumneko(Class->GetParent())) : TEXT(""),
+		Class->GetParent()
+			? *(TEXT(" : ") + FINGenLuaGetTypeNameSumneko(Class->GetParent()))
+			: TEXT(""),
 		*Class->GetInternalName()
 	));
-	
-	for (const UFINProperty* Prop : Class->GetProperties(false)) {
+
+	for (const UFINProperty *Prop : Class->GetProperties(false)) {
 		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) {
 			FINGenLuaPropertySumneko(Documentation, Ref, Class->GetInternalName(), Prop);
 		}
 	}
-	
-	for (const UFINFunction* Func : Class->GetFunctions(false)) {
+
+	for (const UFINFunction *Func : Class->GetFunctions(false)) {
 		//TODO: filter FIN_Operators
 		if (Func->GetFunctionFlags() & FIN_Func_MemberFunc) {
 			FINGenLuaFunctionSumneko(Documentation, Ref, Class->GetInternalName(), Func);
 		}
 	}
 
-	for (const UFINSignal* Signal : Class->GetSignals(false)) {
+	for (const UFINSignal *Signal : Class->GetSignals(false)) {
 		FINGenLuaSignalSumneko(Documentation, Ref, Class->GetInternalName(), Signal);
 	}
 }
 
-void FINGenLuaStructSumneko(FString& Documentation, FFINReflection& Ref, const UFINStruct* Struct) {
+void FINGenLuaStructSumneko(FString &Documentation, FFINReflection &Ref, const UFINStruct *Struct) {
 	Documentation.Append(TEXT("\n"));
 
 	FINGenLuaDescriptionSumneko(Documentation, Struct->GetDescription().ToString());
@@ -264,14 +295,14 @@ void FINGenLuaStructSumneko(FString& Documentation, FFINReflection& Ref, const U
 		*FINGenLuaGetTypeNameSumneko(Struct),
 		*Struct->GetInternalName()
 	));
-	
-	for (const UFINProperty* Prop : Struct->GetProperties(false)) {
+
+	for (const UFINProperty *Prop : Struct->GetProperties(false)) {
 		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) {
 			FINGenLuaPropertySumneko(Documentation, Ref, Struct->GetInternalName(), Prop);
 		}
 	}
-	
-	for (const UFINFunction* Func : Struct->GetFunctions(false)) {
+
+	for (const UFINFunction *Func : Struct->GetFunctions(false)) {
 		//TODO: filter FIN_Operators
 		if (Func->GetFunctionFlags() & FIN_Func_MemberFunc) {
 			FINGenLuaFunctionSumneko(Documentation, Ref, Struct->GetInternalName(), Func);
@@ -279,13 +310,13 @@ void FINGenLuaStructSumneko(FString& Documentation, FFINReflection& Ref, const U
 	}
 }
 
-bool FINGenLuaDocSumneko(UWorld* World, const TCHAR* Command, FOutputDevice& Ar) {
+bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar) {
 	if (FParse::Command(&Command, TEXT("FINGenLuaDocSumneko"))) {
 		FString Documentation;
 
 		Documentation.Append(TEXT("---@meta\n---@diagnostic disable\n\n"));
-		
-		FFINReflection& Ref = *FFINReflection::Get();
+
+		FFINReflection &Ref = *FFINReflection::Get();
 
 		for (TPair<UClass*, UFINClass*> const Class : Ref.GetClasses()) {
 			FINGenLuaClassSumneko(Documentation, Ref, Class.Value);
@@ -304,5 +335,5 @@ bool FINGenLuaDocSumneko(UWorld* World, const TCHAR* Command, FOutputDevice& Ar)
 }
 #pragma optimize("", on)
 
-// ReSharper disable once CppDeclaratorNeverUsed
+[[maybe_unused]]
 static FStaticSelfRegisteringExec FINGenLuaDocSumnekoStaticExec(&FINGenLuaDocSumneko);

--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
@@ -432,8 +432,8 @@ bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar)
 		FString Documentation;
 		Documentation.Append(FINGenLuaSumnekoDocumentationStart);
 
-		FString ClassesString = "---@class FIN.classes\n";
-		FString StructsString = "---@class FIN.structs\n";
+		FString ClassesString = "---@class FIN.classes";
+		FString StructsString = "---@class FIN.structs";
 
 		{
 			// adding "do" and "end" to get rid of local maximum variables reached
@@ -445,7 +445,7 @@ bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar)
 
 				Documentation.Append(FINGenLuaSumnekoClass(Ref, Class.Value));
 				ClassesString.Append(FString::Printf(
-					TEXT("---@field %s %s\n"),
+					TEXT("\n---@field %s %s"),
 					*Class.Value->GetInternalName(),
 					*FINGenLuaSumnekoGetTypeName(Class.Value)
 				));
@@ -463,7 +463,7 @@ bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar)
 
 				Documentation.Append(FINGenLuaSumnekoStruct(Ref, Struct.Value));
 				StructsString.Append(FString::Printf(
-					TEXT("---@field %s %s\n"),
+					TEXT("\n---@field %s %s"),
 					*Struct.Value->GetInternalName(),
 					*FINGenLuaSumnekoGetTypeName(Struct.Value)
 				));
@@ -486,7 +486,7 @@ bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar)
 classes = {}
 
 %s
-strcuts = {}
+structs = {}
 )"), *ClassesString, *StructsString));
 
 		Documentation.Append(FINGenLuaSumnekoDocumentationEnd);

--- a/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
+++ b/Source/FicsItNetworks/Private/Utils/FINGenLuaDocSumneko.cpp
@@ -11,36 +11,41 @@
 #include "UObject/Package.h"
 
 #pragma optimize("", off)
-FString FINGenLuaGetTypeNameSumneko(const UFINBase *Base) {
+FString FINGenLuaSumnekoGetTypeName(const UFINBase *Base) {
 	TArray<FString> SplitBasePackageName;
 	Base->GetPackage()->GetName().ParseIntoArray(SplitBasePackageName, TEXT("/"), true);
 
 	FString BasePackageName;
-	for (auto BasePackageNamePart : SplitBasePackageName) {
-		// get rid of unnecessary names
-		if (BasePackageNamePart.Equals(TEXT("Script"))
-			|| BasePackageNamePart.Equals(TEXT("Game"))
-			|| BasePackageNamePart.Equals(TEXT("Engine"))
-			|| BasePackageNamePart.Equals(TEXT("CoreUObject"))) {
+	for (auto &NamePart : SplitBasePackageName) {
+		if (NamePart.Equals(TEXT("Script"))) {
 			continue;
 		}
 
-		// making it easier and smaller to use types
-		if (BasePackageNamePart.Equals(TEXT("FactoryGame"))) {
+		// we only want the the first not filtered out name should be the mod name
+		if (NamePart.Equals(TEXT("CoreUObject"))) {
+			BasePackageName += TEXT("Engine.");
+			break;
+		}
+
+		// replace mod and Satisfactory name to make type names smaller
+		else if (NamePart.Equals(TEXT("FactoryGame"))
+			|| NamePart.Equals(TEXT("Game"))) {
 			BasePackageName += TEXT("Satis.");
-			continue;
-		} else if (BasePackageNamePart.Equals(TEXT("FicsItNetworks"))) {
+			break;
+		} else if (NamePart.Equals(TEXT("FicsItNetworks"))
+			|| NamePart.Equals(TEXT("FicsItNetworksLua"))) {
 			BasePackageName += TEXT("FIN.");
-			continue;
+			break;
 		}
 
-		BasePackageName += BasePackageNamePart + TEXT(".");
+		BasePackageName += NamePart + TEXT(".");
+		break;
 	}
 
 	return BasePackageName + Base->GetInternalName();
 }
 
-FString FINGenLuaGetTypeSumneko(FFINReflection &Ref, const UFINProperty *Prop) {
+FString FINGenLuaSumnekoGetType(FFINReflection &Ref, const UFINProperty *Prop) {
 	if (!Prop) {
 		return "any";
 	}
@@ -59,33 +64,33 @@ FString FINGenLuaGetTypeSumneko(FFINReflection &Ref, const UFINProperty *Prop) {
 		const UFINObjectProperty *ObjProp = Cast<UFINObjectProperty>(Prop);
 		const UFINClass *Class = Ref.FindClass(ObjProp->GetSubclass());
 		if (!Class)
-			return "Object";
-		return FINGenLuaGetTypeNameSumneko(Class);
+			return "Engine.Object";
+		return FINGenLuaSumnekoGetTypeName(Class);
 	}
 	case FIN_TRACE: {
 		const UFINTraceProperty *TraceProp = Cast<UFINTraceProperty>(Prop);
 		const UFINClass *Class = Ref.FindClass(TraceProp->GetSubclass());
 		if (!Class)
-			return "Object";
-		return FINGenLuaGetTypeNameSumneko(Class);
+			return "Engine.Object";
+		return FINGenLuaSumnekoGetTypeName(Class);
 	}
 	case FIN_CLASS: {
 		const UFINClassProperty *ClassProp = Cast<UFINClassProperty>(Prop);
 		const UFINClass *Class = Ref.FindClass(ClassProp->GetSubclass());
 		if (!Class)
-			return "Object";
-		return FINGenLuaGetTypeNameSumneko(Class);
+			return "Engine.Object";
+		return FINGenLuaSumnekoGetTypeName(Class);
 	}
 	case FIN_STRUCT: {
 		const UFINStructProperty *StructProp = Cast<UFINStructProperty>(Prop);
 		const UFINStruct *Struct = Ref.FindStruct(StructProp->GetInner());
 		if (!Struct)
 			return "any";
-		return FINGenLuaGetTypeNameSumneko(Struct);
+		return FINGenLuaSumnekoGetTypeName(Struct);
 	}
 	case FIN_ARRAY: {
 		const UFINArrayProperty *ArrayProp = Cast<UFINArrayProperty>(Prop);
-		return FINGenLuaGetTypeSumneko(Ref, ArrayProp->GetInnerType()) + "[]";
+		return FINGenLuaSumnekoGetType(Ref, ArrayProp->GetInnerType()) + "[]";
 	}
 	default:
 		return "any";
@@ -93,78 +98,78 @@ FString FINGenLuaGetTypeSumneko(FFINReflection &Ref, const UFINProperty *Prop) {
 }
 
 FString FormatDescription(FString Description) {
+	// assuming its only LF line endings
 	Description.ReplaceCharInline('\n', ' ');
-	Description.ReplaceCharInline('\r', ' ');
 	return Description;
 }
 
-void FINGenLuaDescriptionSumneko(FString &Documentation, FString Description) {
+void FINGenLuaSumnekoDescription(FString &Str, FString Description) {
 	Description.ReplaceInline(TEXT("\r\n"), TEXT("\n"));
 
 	FString Line;
 	while (Description.Split(TEXT("\n"), &Line, &Description)) {
-		Documentation.Append(TEXT("--- ") + Line + TEXT("<br>\n"));
+		Str.Append(TEXT("--- ") + Line + TEXT("<br>\n"));
 	}
-	Documentation.Append(TEXT("--- ") + Description + TEXT("\n"));
+	Str.Append(TEXT("--- ") + Description + TEXT("\n"));
 }
 
-void FINGenLuaPropertySumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
-                              const UFINProperty *Prop) {
-	Documentation.Append(TEXT("\n"));
+FString FINGenLuaSumnekoProperty(FFINReflection &Ref, const FString &Parent,
+                                 const UFINProperty *Prop) {
+	FString PropertyDocumentation = "\n";
 
 	const EFINRepPropertyFlags PropFlags = Prop->GetPropertyFlags();
-	FINGenLuaDescriptionSumneko(Documentation, TEXT("### Flags:"));
+	FINGenLuaSumnekoDescription(PropertyDocumentation, TEXT("### Flags:"));
 
 	if (PropFlags & FIN_Prop_RT_Sync) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
+		FINGenLuaSumnekoDescription(PropertyDocumentation,
+		                            TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
 	}
 
 	if (PropFlags & FIN_Prop_RT_Parallel) {
-		FINGenLuaDescriptionSumneko(Documentation,
+		FINGenLuaSumnekoDescription(PropertyDocumentation,
 		                            TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
 	}
 
 	if (PropFlags & FIN_Prop_RT_Async) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
+		FINGenLuaSumnekoDescription(PropertyDocumentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
 	}
 
 	if (PropFlags & FIN_Prop_ReadOnly) {
-		FINGenLuaDescriptionSumneko(Documentation,
+		FINGenLuaSumnekoDescription(PropertyDocumentation,
 		                            TEXT("* Read Only - The value of this property can not be changed by code."));
 	}
 
-	Documentation.Append(FString::Printf(TEXT("---@type %s\n"), *FINGenLuaGetTypeSumneko(Ref, Prop)));
-	Documentation.Append(FString::Printf(TEXT("%s.%s = nil\n"), *Parent, *Prop->GetInternalName()));
+	PropertyDocumentation.Append(FString::Printf(
+		TEXT("---@type %s\n%s.%s = nil\n"), *FINGenLuaSumnekoGetType(Ref, Prop), *Parent, *Prop->GetInternalName()));
+
+	return PropertyDocumentation;
 }
 
-void FINGenLuaFunctionSumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
-                              const UFINFunction *Func) {
-	Documentation.Append(TEXT("\n"));
+FString FINGenLuaSumnekoFunction(FFINReflection &Ref, const FString &Parent,
+                                 const UFINFunction *Func) {
+	FString FunctionDocumentation = "\n";
 
-	FINGenLuaDescriptionSumneko(Documentation, Func->GetDescription().ToString());
+	FINGenLuaSumnekoDescription(FunctionDocumentation, Func->GetDescription().ToString());
 
 	const EFINFunctionFlags funcFlags = Func->GetFunctionFlags();
-	FINGenLuaDescriptionSumneko(Documentation, TEXT("### Flags:"));
+	FINGenLuaSumnekoDescription(FunctionDocumentation, TEXT("### Flags:"));
 
 	if (funcFlags & FIN_Func_RT_Sync) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
+		FINGenLuaSumnekoDescription(FunctionDocumentation,
+		                            TEXT("* Runtime Synchronous - Can be called/changed in Game Tick."));
 	}
 
 	if (funcFlags & FIN_Func_RT_Parallel) {
-		FINGenLuaDescriptionSumneko(Documentation,
+		FINGenLuaSumnekoDescription(FunctionDocumentation,
 		                            TEXT("* Runtime Parallel - Can be called/changed in Satisfactory Factory Tick."));
 	}
 
 	if (funcFlags & FIN_Func_RT_Async) {
-		FINGenLuaDescriptionSumneko(Documentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
+		FINGenLuaSumnekoDescription(FunctionDocumentation, TEXT("* Runtime Asynchronous - Can be changed anytime."));
 	}
 
-	if (funcFlags & FIN_Func_VarArgs) {
-		FINGenLuaDescriptionSumneko(Documentation,
-		                            TEXT("* Variable Arguments - Can have any additional arguments as described."));
-	}
-
-	FString ReturnValues;
+	FString ParamDocumentation;
+	FString ReturnDocumentation;
 	FString ParamList;
 	for (const UFINProperty *Prop : Func->GetParameters()) {
 		const EFINRepPropertyFlags Flags = Prop->GetPropertyFlags();
@@ -174,16 +179,15 @@ void FINGenLuaFunctionSumneko(FString &Documentation, FFINReflection &Ref, const
 		}
 
 		if (Flags & FIN_Prop_OutParam) {
-			if (ReturnValues.Len() > 0) {
-				ReturnValues.Append(",");
-			}
-
-			ReturnValues.Append(*FINGenLuaGetTypeSumneko(Ref, Prop));
+			ReturnDocumentation.Append(FString::Printf(TEXT("---@return %s %s @%s\n"),
+			                                           *FINGenLuaSumnekoGetType(Ref, Prop),
+			                                           *Prop->GetInternalName(),
+			                                           *FormatDescription(Prop->GetDescription().ToString())));
 		} else {
-			Documentation.Append(FString::Printf(
+			ParamDocumentation.Append(FString::Printf(
 				TEXT("---@param %s %s @%s\n"),
 				*Prop->GetInternalName(),
-				*FINGenLuaGetTypeSumneko(Ref, Prop),
+				*FINGenLuaSumnekoGetType(Ref, Prop),
 				*FormatDescription(Prop->GetDescription().ToString())
 			));
 
@@ -196,7 +200,7 @@ void FINGenLuaFunctionSumneko(FString &Documentation, FFINReflection &Ref, const
 	}
 
 	if (funcFlags & FIN_Func_VarArgs) {
-		Documentation.Append(TEXT("---@param ... any @additional arguments as described"));
+		ParamDocumentation.Append(TEXT("---@param ... any @additional arguments as described\n"));
 
 		if (ParamList.Len() > 0) {
 			ParamList.Append(", ");
@@ -205,47 +209,52 @@ void FINGenLuaFunctionSumneko(FString &Documentation, FFINReflection &Ref, const
 		ParamList.Append("...");
 	}
 
-	if (ReturnValues.Len() > 0) {
-		Documentation.Append(FString::Printf(TEXT("---@return %s\n"), *ReturnValues));
-	}
+	FunctionDocumentation.Append(
+		FString::Printf(TEXT("%s%sfunction %s:%s(%s) end\n"),
+		                *ParamDocumentation,
+		                *ReturnDocumentation,
+		                *Parent,
+		                *Func->GetInternalName(),
+		                *ParamList));
 
-	Documentation.Append(
-		FString::Printf(TEXT("function %s:%s(%s) end\n"), *Parent, *Func->GetInternalName(), *ParamList));
+	return FunctionDocumentation;
 }
 
-void FINGenLuaSignalSumneko(FString &Documentation, FFINReflection &Ref, const FString &Parent,
-                            const UFINSignal *Signal) {
-	Documentation.Append(TEXT("\n"));
+FString FINGenLuaSumnekoSignal(FFINReflection &Ref, const FString &Parent,
+                               const UFINSignal *Signal) {
+	FString SignalDocumentation = "\n";
 
-	FINGenLuaDescriptionSumneko(Documentation, Signal->GetDescription().ToString() + TEXT("\n"));
+	FINGenLuaSumnekoDescription(SignalDocumentation, Signal->GetDescription().ToString() + TEXT("\n"));
 
-	FINGenLuaDescriptionSumneko(Documentation, TEXT("### returns from event.pull:\n```"));
+	FINGenLuaSumnekoDescription(SignalDocumentation, TEXT("### returns from event.pull:\n```"));
 
-	Documentation.Append(TEXT("--- local signalName, component"));
+	SignalDocumentation.Append(TEXT("--- local signalName, component"));
 	for (const UFINProperty *Prop : Signal->GetParameters()) {
-		Documentation.Append(TEXT(", ") + Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")));
+		SignalDocumentation.Append(TEXT(", ") + Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")));
 	}
 	if (Signal->IsVarArgs()) {
-		Documentation.Append(TEXT(", ..."));
+		SignalDocumentation.Append(TEXT(", ..."));
 	}
-	Documentation.Append(TEXT(" = event.pull()\n--- ```\n"));
+	SignalDocumentation.Append(TEXT(" = event.pull()\n--- ```\n"));
 
-	FINGenLuaDescriptionSumneko(Documentation,
+	FINGenLuaSumnekoDescription(SignalDocumentation,
 	                            FString::Printf(TEXT("- `signalName: \"%s\"`"), *Signal->GetInternalName()));
-	FINGenLuaDescriptionSumneko(Documentation, FString::Printf(TEXT("- `component: %s`"), *Parent));
+	FINGenLuaSumnekoDescription(SignalDocumentation,
+	                            FString::Printf(TEXT("- `component: %s`"), *Parent));
 
 	for (const UFINProperty *Prop : Signal->GetParameters()) {
-		FINGenLuaDescriptionSumneko(Documentation, FString::Printf(
+		FINGenLuaSumnekoDescription(SignalDocumentation,
+		                            FString::Printf(
 			                            TEXT("- `%s: %s` \n%s"),
 			                            *Prop->GetDisplayName().ToString().Replace(TEXT(" "), TEXT("")),
-			                            *FINGenLuaGetTypeSumneko(Ref, Prop),
+			                            *FINGenLuaSumnekoGetType(Ref, Prop),
 			                            *Prop->GetDescription().ToString()
 		                            ));
 	}
 
 	// hard coding the type is maybe not the best choice
-	Documentation.Append(TEXT("---@deprecated\n---@type FIN.Signal\n"));
-	Documentation.Append(FString::Printf(
+	SignalDocumentation.Append(TEXT("---@deprecated\n---@type FIN.Signal\n"));
+	SignalDocumentation.Append(FString::Printf(
 		TEXT("%s.%s = { isVarArgs = %s }\n"),
 		*Parent,
 		*Signal->GetInternalName(),
@@ -253,77 +262,129 @@ void FINGenLuaSignalSumneko(FString &Documentation, FFINReflection &Ref, const F
 			? TEXT("true")
 			: TEXT("false")
 	));
+
+	return SignalDocumentation;
 }
 
-void FINGenLuaClassSumneko(FString &Documentation, FFINReflection &Ref, const UFINClass *Class) {
+void FINGenLuaSumnekoClass(FString &Documentation, FFINReflection &Ref, const UFINClass *Class) {
 	Documentation.Append(TEXT("\n"));
 
-	FINGenLuaDescriptionSumneko(Documentation, Class->GetDescription().ToString());
+	FINGenLuaSumnekoDescription(Documentation, Class->GetDescription().ToString());
 	Documentation.Append(FString::Printf(
 		TEXT("---@class %s%s\nlocal %s\n"),
-		*FINGenLuaGetTypeNameSumneko(Class),
-		Class->GetParent()
-			? *(TEXT(" : ") + FINGenLuaGetTypeNameSumneko(Class->GetParent()))
-			: TEXT(""),
+		*FINGenLuaSumnekoGetTypeName(Class),
+		*(Class->GetParent()
+			  ? TEXT(" : ") + FINGenLuaSumnekoGetTypeName(Class->GetParent())
+			  : TEXT("")),
 		*Class->GetInternalName()
 	));
 
 	for (const UFINProperty *Prop : Class->GetProperties(false)) {
 		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) {
-			FINGenLuaPropertySumneko(Documentation, Ref, Class->GetInternalName(), Prop);
+			Documentation.Append(FINGenLuaSumnekoProperty(Ref, Class->GetInternalName(), Prop));
 		}
 	}
 
 	for (const UFINFunction *Func : Class->GetFunctions(false)) {
 		//TODO: filter FIN_Operators
 		if (Func->GetFunctionFlags() & FIN_Func_MemberFunc) {
-			FINGenLuaFunctionSumneko(Documentation, Ref, Class->GetInternalName(), Func);
+			Documentation.Append(FINGenLuaSumnekoFunction(Ref, Class->GetInternalName(), Func));
 		}
 	}
 
 	for (const UFINSignal *Signal : Class->GetSignals(false)) {
-		FINGenLuaSignalSumneko(Documentation, Ref, Class->GetInternalName(), Signal);
+		Documentation.Append(FINGenLuaSumnekoSignal(Ref, Class->GetInternalName(), Signal));
 	}
 }
 
-void FINGenLuaStructSumneko(FString &Documentation, FFINReflection &Ref, const UFINStruct *Struct) {
+void FINGenLuaSumnekoStruct(FString &Documentation, FFINReflection &Ref, const UFINStruct *Struct) {
 	Documentation.Append(TEXT("\n"));
 
-	FINGenLuaDescriptionSumneko(Documentation, Struct->GetDescription().ToString());
+	FINGenLuaSumnekoDescription(Documentation, Struct->GetDescription().ToString());
 	Documentation.Append(FString::Printf(
 		TEXT("---@class %s\nlocal %s\n"),
-		*FINGenLuaGetTypeNameSumneko(Struct),
+		*FINGenLuaSumnekoGetTypeName(Struct),
 		*Struct->GetInternalName()
 	));
 
 	for (const UFINProperty *Prop : Struct->GetProperties(false)) {
 		if (Prop->GetPropertyFlags() & FIN_Prop_Attrib) {
-			FINGenLuaPropertySumneko(Documentation, Ref, Struct->GetInternalName(), Prop);
+			Documentation.Append(FINGenLuaSumnekoProperty(Ref, Struct->GetInternalName(), Prop));
 		}
 	}
 
 	for (const UFINFunction *Func : Struct->GetFunctions(false)) {
 		//TODO: filter FIN_Operators
 		if (Func->GetFunctionFlags() & FIN_Func_MemberFunc) {
-			FINGenLuaFunctionSumneko(Documentation, Ref, Struct->GetInternalName(), Func);
+			Documentation.Append(FINGenLuaSumnekoFunction(Ref, Struct->GetInternalName(), Func));
 		}
 	}
 }
 
 bool FINGenLuaDocSumneko(UWorld *World, const TCHAR *Command, FOutputDevice &Ar) {
 	if (FParse::Command(&Command, TEXT("FINGenLuaDocSumneko"))) {
-		FString Documentation;
-
-		Documentation.Append(TEXT("---@meta\n---@diagnostic disable\n\n"));
-
 		FFINReflection &Ref = *FFINReflection::Get();
+		FString Documentation;
+		Documentation.Append(FINGenLuaSumnekoDocumentationStart);
+		
+		FString ClassesString = "---@class FIN.classes\n";
+		FString StructsString = "---@class FIN.structs\n";
 
-		for (TPair<UClass*, UFINClass*> const Class : Ref.GetClasses()) {
-			FINGenLuaClassSumneko(Documentation, Ref, Class.Value);
+		{
+			// adding "do" and "end" to get rid of local maximum variables reached
+			int32_t count = 0;
+			for (TPair<UClass*, UFINClass*> const Class : Ref.GetClasses()) {
+				if (count == 0) {
+					Documentation.Append("do\n");
+				}
+
+				FINGenLuaSumnekoClass(Documentation, Ref, Class.Value);
+				ClassesString.Append(FString::Printf(
+					TEXT("---@field %s %s\n"),
+					*Class.Value->GetInternalName(),
+					*FINGenLuaSumnekoGetTypeName(Class.Value)
+				));
+				count++;
+
+				if (count == 180) {
+					Documentation.Append("\nend\n");
+					count = 0;
+				}
+			}
+			for (TPair<UScriptStruct*, UFINStruct*> const Struct : Ref.GetStructs()) {
+				if (count == 0) {
+					Documentation.Append("do\n");
+				}
+
+				FINGenLuaSumnekoStruct(Documentation, Ref, Struct.Value);
+				StructsString.Append(FString::Printf(
+					TEXT("---@field %s %s\n"),
+					*Struct.Value->GetInternalName(),
+					*FINGenLuaSumnekoGetTypeName(Struct.Value)
+				));
+				count++;
+
+				if (count == 180) {
+					Documentation.Append("\nend\n");
+					count = 0;
+				}
+			}
+
+			if (count != 0) {
+				Documentation.Append("\nend\n");
+			}
 		}
-		for (TPair<UScriptStruct*, UFINStruct*> const Struct : Ref.GetStructs()) {
-			FINGenLuaStructSumneko(Documentation, Ref, Struct.Value);
-		}
+
+		// this looks wierd, but gets indented this way by my formatting settings
+		Documentation.Append(FString::Printf(TEXT(R"(
+%s
+classes = {}
+
+%s
+strcuts = {}
+)"), *ClassesString, *StructsString));
+
+		Documentation.Append(FINGenLuaSumnekoDocumentationEnd);
 
 		FString Path = FPaths::Combine(FPlatformProcess::UserSettingsDir(), FApp::GetProjectName(), TEXT("Saved/"));
 		Path = FPaths::Combine(Path, TEXT("FINLuaDocumentationSumneko.lua"));

--- a/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
+++ b/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
@@ -1,17 +1,12 @@
 ﻿#pragma once
 
-#include "Reflection/FINReflection.h"
-
-void FINGenLuaSumnekoClass(FString& Documentation, FFINReflection& Ref, const UFINClass* Class);
-bool FINGenLuaDocSumneko(UWorld* World, const TCHAR* Command, FOutputDevice& Ar);
-
 // this is a terible way of doing documentation but currently only way without modifing any additional code for documentation.
-inline const auto FINGenLuaSumnekoDocumentationStart = TEXT(R"(error("I don't know what your misson is. But is file is not meant to be executed in any way. It's a meta file.\")
+inline const auto FINGenLuaSumnekoDocumentationStart = TEXT(R"(error("I don't know what your misson is. But is file is not meant to be executed in any way. It's a meta file.")
 ---@meta
 ---@diagnostic disable
 )");
 
-	inline const auto MiscDocumentation = TEXT(R"(
+inline const auto MiscDocumentation = TEXT(R"(
 -- some more FicsIt-Networks things to support more type specific things and also adds documentation for `computer`, `component`, `event` and `filesystem` libraries in FicsIt-Networks (keep in mind this is all written by hand and can maybe not represent all features available)
 
 --- # Not in FicsIt-Networks available #
@@ -76,7 +71,34 @@ function findItem(name) end
 function getItems(...) end
 )");
 
-	inline const auto EventApiDocumentation = TEXT(R"(
+inline const auto FutureApiDocumentation = TEXT(R"(
+---@class FIN.Future
+local Future = {}
+
+--- Waits for the future to finish processing and returns the result.
+--- ### Flags:
+--- * Unknown
+---@async
+---@return any ...
+function Future:await()
+end
+
+--- Gets the data.
+--- ### Flags:
+--- * Unknown
+---@return any ...
+function Future:get()
+end
+
+--- Checks if the Future is done processing.
+--- ### Flags:
+--- * Unknown
+---@return boolean isDone
+function Future:canGet()
+end
+)");
+
+inline const auto EventApiDocumentation = TEXT(R"(
 --- **FicsIt-Networks Lua Lib:** `event`
 ---
 --- The Event API provides classes, functions and variables for interacting with the component network.
@@ -110,7 +132,7 @@ function event.ignoreAll() end
 function event.clear() end
 )");
 	
-	inline const auto ComponentApiDocumentation = TEXT(R"(
+inline const auto ComponentApiDocumentation = TEXT(R"(
 --- **FicsIt-Networks Lua Lib:** `component`
 ---
 --- The Component API provides structures, functions and signals for interacting with the network itself like returning network components.
@@ -172,7 +194,7 @@ function component.findComponent(type) end
 function component.findComponent(...) end
 )");
 	
-	inline const auto ComputerApiDocumentation = TEXT(R"(
+inline const auto ComputerApiDocumentation = TEXT(R"(
 --- **FicsIt-Networks Lua Lib:** `computer`
 ---
 --- The Computer API provides a interface to the computer owns functionalities.
@@ -264,7 +286,7 @@ function computer.textNotification(text, playerName) end
 function computer.attentionPing(position, playerName) end
 )");
 	
-	inline const auto FileSystemApiDocumentation = TEXT(R"(
+inline const auto FileSystemApiDocumentationPart1 = TEXT(R"(
 --- **FicsIt-Networks Lua Lib:** `filesystem`
 ---
 --- The filesystem api provides structures, functions and variables for interacting with the virtual file systems.
@@ -353,7 +375,9 @@ function filesystem.children(path) end
 ---@param path string - path you want to check if it refers to a file
 ---@return boolean isFile - true if path refers to a file
 function filesystem.isFile(path) end
+)");
 
+inline const auto FileSystemApiDocumentationPart2 = TEXT(R"(
 --- Checks if given path refers to a directory.
 ---@param path string - path you want to check if it refers to a directory
 ---@return boolean isDir - returns true if path refers to a directory
@@ -410,7 +434,7 @@ function filesystem.path(parameter, ...) end
 
 --- Will be checked for lexical features.
 --- Return value which is a bit-flag-register describing those lexical features.
----@param path string - filesystem-path you want to get lexical features from.
+---@param path string - filesystem-path you want to get lexical features from. 
 ---@return FIN.Filesystem.PathRegister BitRegister - bit-register describing the features of each path
 function filesystem.analyzePath(path) end
 
@@ -430,6 +454,29 @@ function filesystem.isNode(node) end
 ---@return boolean ... - True if the corresponding string is a valid node-name.
 function filesystem.isNode(...) end
 )");
-	
-	const FString FINGenLuaSumnekoDocumentationEnd = FString::Printf(TEXT("%s\n%s\n%s\n%s\n%s\n"),
-		MiscDocumentation, EventApiDocumentation, ComponentApiDocumentation, ComputerApiDocumentation, FileSystemApiDocumentation);
+
+inline const auto FileApiDocumentation = TEXT(R"(
+---@class FIN.Filesystem.File
+local File = {}
+
+---@param data string
+function File:write(data) end
+
+---@param length integer
+function File:read(length) end
+
+---@alias FIN.Filesystem.File.SeekMode
+---|"set" # Base is beginning of the file.
+---|"cur" # Base is current position.
+---|"end" # Base is end of file.
+
+---@param mode FIN.Filesystem.File.SeekMode
+---@param offset integer
+---@return integer offset
+function File:seek(mode, offset) end
+
+function File:close() end
+)");
+
+const FString FINGenLuaSumnekoDocumentationEnd = FString::Printf(TEXT("%s\n%s\n%s\n%s\n%s\n%s%s\n%s"),
+	MiscDocumentation, FutureApiDocumentation, EventApiDocumentation, ComponentApiDocumentation, ComputerApiDocumentation, FileSystemApiDocumentationPart1, FileSystemApiDocumentationPart2, FileApiDocumentation);

--- a/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
+++ b/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
@@ -2,5 +2,434 @@
 
 #include "Reflection/FINReflection.h"
 
-void FINGenLuaClassSumneko(FString& Documentation, FFINReflection& Ref, const UFINClass* Class);
+void FINGenLuaSumnekoClass(FString& Documentation, FFINReflection& Ref, const UFINClass* Class);
 bool FINGenLuaDocSumneko(UWorld* World, const TCHAR* Command, FOutputDevice& Ar);
+
+// this is a terible way of doing documentation but currently only way without modifing any additional code for documentation.
+inline const auto FINGenLuaSumnekoDocumentationStart = TEXT(R"(error("I don't know what your misson is. But is file is not meant to be executed in any way. It's a meta file.\")
+---@meta
+---@diagnostic disable
+)");
+
+	inline const auto MiscDocumentation = TEXT(R"(
+-- some more FicsIt-Networks things to support more type specific things and also adds documentation for `computer`, `component`, `event` and `filesystem` libraries in FicsIt-Networks (keep in mind this is all written by hand and can maybe not represent all features available)
+
+--- # Not in FicsIt-Networks available #
+package = nil
+
+--- # Not in FicsIt-Networks available #
+os = nil
+
+--- # Not in FicsIt-Networks available #
+collectgarbage = nil
+
+--- # Not in FicsIt-Networks available #
+io = nil
+
+--- # Not in FicsIt-Networks available #
+arg = nil
+
+--- # Not in FicsIt-Networks available #
+require = nil
+
+---@class FIN.UUID : string
+
+
+-- adding alias to make more descriptive correct naming and more plausible when using `computer.getPCIDevice()`
+
+---@alias FIN.PCIDevice FIN.FINComputerModule
+
+---@class Engine.Object
+local Object = {}
+
+--- The network id of this component.
+---
+--- ## Only on objects that are network components.
+--- ### Flags:
+--- * ? Runtime Synchronous - Can be called/changed in Game Tick ?
+--- * ? Runtime Parallel - Can be called/changed in Satisfactory Factory Tick ?
+--- * Read Only - The value of this property can not be changed by code
+---@type FIN.UUID
+Object.id = nil
+
+--- The nick you gave the component in the network its in.
+--- If it has no nick name it returns `nil`.
+---
+--- ## Only on objects that are network components.
+--- ### Flags:
+--- * ? Runtime Synchronous - Can be called/changed in Game Tick ?
+--- * ? Runtime Parallel - Can be called/changed in Satisfactory Factory Tick ?
+--- * Read Only - The value of this property can not be changed by code
+---@type string
+Object.nick = nil
+
+-- global functions from FicsIt-Networks
+
+--- Tries to find the item with the provided name.
+---@param name string
+---@return Engine.Object
+function findItem(name) end
+
+--- Tries to find the items or item provided via name.
+---@param ... string
+---@return Engine.Object[]
+function getItems(...) end
+)");
+
+	inline const auto EventApiDocumentation = TEXT(R"(
+--- **FicsIt-Networks Lua Lib:** `event`
+---
+--- The Event API provides classes, functions and variables for interacting with the component network.
+---@class FIN.Event.Api
+event = {}
+
+--- Adds the running lua context to the listen queue of the given component.
+---@param component Engine.Object - The network component lua representation the computer should now listen to.
+function event.listen(component) end
+
+--- Returns all signal senders this computer is listening to.
+---@return Engine.Object[] components - An array containing instances to all sginal senders this computer is listening too.
+function event.listening() end
+
+--- Waits for a signal in the queue. Blocks the execution until a signal got pushed to the signal queue, or the timeout is reached.
+--- Returns directly if there is already a signal in the queue (the tick doesn’t get yielded).
+---@param timeoutSeconds number? - The amount of time needs to pass until pull unblocks when no signal got pushed.
+---@return string signalName - The name of the returned signal.
+---@return Engine.Object component - The component representation of the signal sender.
+---@return any ... - The parameters passed to the signal.
+function event.pull(timeoutSeconds) end
+
+--- Removes the running lua context from the listen queue of the given components. Basically the opposite of listen.
+---@param component Engine.Object - The network component lua representations the computer should stop listening to.
+function event.ignore(component) end
+
+--- Stops listening to any signal sender. If afterwards there are still coming signals in, it might be the system itself or caching bug.
+function event.ignoreAll() end
+
+--- Clears every signal from the signal queue.
+function event.clear() end
+)");
+	
+	inline const auto ComponentApiDocumentation = TEXT(R"(
+--- **FicsIt-Networks Lua Lib:** `component`
+---
+--- The Component API provides structures, functions and signals for interacting with the network itself like returning network components.
+---@class FIN.Component.Api
+component = {}
+
+
+--- Generates and returns instances of the network component with the given UUID.
+--- If a network component cannot be found for a given UUID, nil will be used for the return. Otherwise, an instance of the network component will be returned.
+---@generic T : Engine.Object
+---@param id FIN.UUID - UUID of a network component.
+---@return T? component
+function component.proxy(id) end
+
+--- Generates and returns instances of the network components with the given UUIDs.
+--- You can pass any amount of parameters and each parameter will then have a corresponding return value.
+--- If a network component cannot be found for a given UUID, nil will be used for the return. Otherwise, an instance of the network component will be returned.
+---@generic T : Engine.Object
+---@param ... FIN.UUID - UUIDs
+---@return T? ... - components
+function component.proxy(...) end
+
+--- Generates and returns instances of the network components with the given UUIDs.
+--- You can pass any amount of parameters and each parameter will then have a corresponding return value.
+--- If a network component cannot be found for a given UUID, nil will be used for the return. Otherwise, an instance of the network component will be returned.
+---@generic T : Engine.Object
+---@param ids FIN.UUID[]
+---@return T[] components
+function component.proxy(ids) end
+
+--- Generates and returns instances of the network components with the given UUIDs.
+--- You can pass any amount of parameters and each parameter will then have a corresponding return value.
+--- If a network component cannot be found for a given UUID, nil will be used for the return. Otherwise, an instance of the network component will be returned.
+---@generic T : Engine.Object
+---@param ... FIN.UUID[]
+---@return T[] ... - components
+function component.proxy(...) end
+
+--- Searches the component network for components with the given query.
+---@param query string
+---@return FIN.UUID[] UUIDs
+function component.findComponent(query) end
+
+--- Searches the component network for components with the given query.
+--- You can pass multiple parameters and each parameter will be handled separately and returns a corresponding return value.
+---@param ... string - querys
+---@return FIN.UUID[] ... - UUIDs
+function component.findComponent(...) end
+
+--- Searches the component network for components with the given type.
+---@param type Engine.Object
+---@return FIN.UUID[] UUIDs
+function component.findComponent(type) end
+
+--- Searches the component network for components with the given type.
+--- You can pass multiple parameters and each parameter will be handled separately and returns a corresponding return value.
+---@param ... Engine.Object - classes to search for
+---@return FIN.UUID[] ... - UUIDs
+function component.findComponent(...) end
+)");
+	
+	inline const auto ComputerApiDocumentation = TEXT(R"(
+--- **FicsIt-Networks Lua Lib:** `computer`
+---
+--- The Computer API provides a interface to the computer owns functionalities.
+---@class FIN.Computer.Api
+computer = {}
+
+--- Returns the current memory usage
+---@return integer usage
+---@return integer capacity
+function computer.getMemory() end
+
+--- Returns the current computer case instance
+---@return FIN.Components.ComputerCase_C
+function computer.getInstance() end
+
+--- Stops the current code execution immediately and queues the system to restart in the next tick.
+function computer.reset() end
+
+--- Stops the current code execution.
+--- Basically kills the PC runtime immediately.
+function computer.stop() end
+
+--- Crashes the computer with the given error message.
+---@param errorMsg string - The crash error message you want to use
+function computer.panic(errorMsg) end
+
+--- This function is mainly used to allow switching to a higher tick runtime state. Usually you use this when you want to make your code run faster when using functions that can run in asynchronous environment.
+function computer.skip() end
+
+--- Does the same as computer.skip
+function computer.promote() end
+
+--- Reverts effects of skip
+function computer.demote() end
+
+--- Returns `true` if the tick state is to higher
+---@return boolean isPromoted
+function computer.isPromoted() end
+
+--- If computer state is async probably after calling computer.skip.
+---@return 0 | 1 state - 0 = Sync, 1 = Async
+function computer.state() end
+
+--- Lets the computer emit a simple beep sound with the given pitch.
+---@param pitch number - The pitch of the beep sound you want to play.
+function computer.beep(pitch) end
+
+--- Sets the code of the current eeprom. Doesn’t cause a system reset.
+---@param code string - The code you want to place into the eeprom.
+function computer.setEEPROM(code) end
+
+--- Returns the code the current eeprom contents.
+---@return string code - The code in the EEPROM
+function computer.getEEPROM() end
+
+--- Returns the number of game seconds passed since the save got created. A game day consists of 24 game hours, a game hour consists of 60 game minutes, a game minute consists of 60 game seconds.
+---@return number time - The number of game seconds passed since the save got created.
+function computer.time() end
+
+--- Returns the amount of milliseconds passed since the system started.
+---@return integer milliseconds - Amount of milliseconds since system start
+function computer.millis() end
+
+--- Returns some kind of strange/mysterious time data from a unknown place (the real life).
+---@return integer Timestamp - Unix Timestamp
+---@return string DateTimeStamp - Serverside Formatted Date-Time-Stamp
+---@return string DateTimeStamp - Date-Time-Stamp after ISO 8601
+function computer.magicTime() end
+
+---@param verbosity FIN.Components.LogEntry.Verbosity
+---@param format string
+---@param ... any
+function computer.log(verbosity, format, ...) end
+
+--- This function allows you to get all installed PCI-Devices in a computer of a given type.
+---@generic TPCIDevice : FIN.PCIDevice
+---@param type TPCIDevice
+---@return TPCIDevice[]
+function computer.getPCIDevices(type) end
+
+--- Shows a text notification to the player. If player is `nil` to all players.
+---@param text string
+---@param playerName string?
+function computer.textNotification(text, playerName) end
+
+--- Creates an attentionPing at the given position to the player. If player is `nil` to all players.
+---@param position Engine.Vector
+---@param playerName string?
+function computer.attentionPing(position, playerName) end
+)");
+	
+	inline const auto FileSystemApiDocumentation = TEXT(R"(
+--- **FicsIt-Networks Lua Lib:** `filesystem`
+---
+--- The filesystem api provides structures, functions and variables for interacting with the virtual file systems.
+---
+--- You can’t access files outside the virtual filesystem. If you try to do so, the Lua runtime crashes.
+---@class FIN.Filesystem.Api
+filesystem = {}
+
+---@alias FIN.Filesystem.Type
+---|"tmpfs" # A temporary filesystem only existing at runtime in the memory of your computer. All data will be lost when the system stops.
+
+--- Trys to create a new file system of the given type with the given name.
+--- The created filesystem will be added to the system DevDevice.
+---@param type FIN.Filesystem.Type - the type of the new filesystem
+---@param name string - the name of the new filesystem you want to create
+---@return boolean success - returns true if it was able to create the new filesystem
+function filesystem.makeFileSystem(type, name) end
+
+--- Trys to remove the filesystem with the given name from the system DevDevice.
+--- All mounts of the device will run invalid.
+---@param name string - the name of the new filesystem you want to remove
+---@return boolean success - returns true if it was able to remove the new filesystem
+function filesystem.removeFileSystem(name) end
+
+--- Trys to mount the system DevDevice to the given location.
+--- The DevDevice is special Device holding DeviceNodes for all filesystems added to the system. (like TmpFS and drives). It is unmountable as well as getting mounted a seccond time.
+---@param path string - path to the mountpoint were the dev device should get mounted to
+---@return boolean success - returns if it was able to mount the DevDevice
+function filesystem.initFileSystem(path) end
+
+---@alias FIN.Filesystem.File.Openmode
+---|"r" read only -> file stream can just read from file. If file doesn’t exist, will return nil
+---|"w" write -> file stream can read and write creates the file if it doesn’t exist
+---|"a" end of file -> file stream can read and write cursor is set to the end of file
+---|"+r" truncate -> file stream can read and write all previous data in file gets dropped
+---|"+a" append -> file stream can read the full file but can only write to the end of the existing file
+
+--- Opens a file-stream and returns it as File-table.
+---@param path string
+---@param mode FIN.Filesystem.File.Openmode
+---@return FIN.Filesystem.File File
+function filesystem.open(path, mode) end
+
+--- Creates the folder path.
+---@param path string - folder path the function should create
+---@param all boolean? - if true creates all sub folders from the path
+---@return boolean success - returns `true` if it was able to create the directory
+function filesystem.createDir(path, all) end
+
+--- Removes the filesystem object at the given path.
+---@param path string - path to the filesystem object
+---@param all boolean? - if true deletes everything
+---@return boolean success - returns `true` if it was able to remove the node
+function filesystem.remove(path, all) end
+
+--- Moves the filesystem object from the given path to the other given path.
+--- Function fails if it is not able to move the object.
+---@param from string - path to the filesystem object you want to move
+---@param to string - path to the filesystem object the target should get moved to
+---@return boolean success - returns `true` if it was able to move the node
+function filesystem.move(from, to) end
+
+--- Renames the filesystem object at the given path to the given name.
+---@param path string - path to the filesystem object you want to rename
+---@param name string - the new name for your filesystem object
+---@return boolean success - returns true if it was able to rename the node
+function filesystem.rename(path, name) end
+
+--- Checks if the given path exists.
+---@param path string - path you want to check if it exists
+---@return boolean exists - true if given path exists
+function filesystem.exists(path) end
+
+--- Lists all children of this node. (f.e. items in a folder)
+---@param path string - path to the filesystem object you want to get the childs from
+---@return string[] childs - array of string which are the names of the childs
+function filesystem.childs(path) end
+
+---@deprecated
+--- Lists all children of this node. (f.e. items in a folder)
+---@param path string - path to the filesystem object you want to get the childs from
+---@return string[] childs - array of string which are the names of the childs
+function filesystem.children(path) end
+
+--- Checks if path refers to a file.
+---@param path string - path you want to check if it refers to a file
+---@return boolean isFile - true if path refers to a file
+function filesystem.isFile(path) end
+
+--- Checks if given path refers to a directory.
+---@param path string - path you want to check if it refers to a directory
+---@return boolean isDir - returns true if path refers to a directory
+function filesystem.isDir(path) end
+
+--- This function mounts the device referenced by the the path to a device node to the given mount point.
+---@param device string - the path to the device you want to mount
+---@param mountPoint string - the path to the point were the device should get mounted to
+function filesystem.mount(device, mountPoint) end
+
+--- This function unmounts the device referenced to the the given mount point.
+---@param mountPoint string - the path to the point were the device is referenced to
+function filesystem.unmount(mountPoint) end
+
+--- Executes Lua code in the file referd by the given path.
+--- Function fails if path doesn’t exist or path doesn’t refer to a file.
+---@param path string - path to file you want to execute as Lua code
+---@return any ... - Returned values from executed file.
+function filesystem.doFile(path) end
+
+--- Loads the file refered by the given path as a Lua function and returns it.
+--- Functions fails if path doesn’t exist or path doesn’t reger to a file.
+---@param path string - path to the file you want to load as Lua function
+---@return function loadedFunction - the file compiled as Lua function
+function filesystem.loadFile(path) end
+
+---@alias FIN.Filesystem.PathParameters
+---|0 Normalize the path. -> /my/../weird/./path → /weird/path
+---|1 Normalizes and converts the path to an absolute path. -> my/abs/path → /my/abs/path
+---|2 Normalizes and converts the path to an relative path. -> /my/relative/path → my/relative/path
+---|3 Returns the whole file/folder name. -> /path/to/file.txt → file.txt
+---|4 Returns the stem of the filename. -> /path/to/file.txt → file || /path/to/.file → .file
+---|5 Returns the file-extension of the filename. -> /path/to/file.txt → .txt || /path/to/.file → empty-str || /path/to/file. → .
+
+--- Combines a variable amount of strings as paths together.
+---@param ... string - paths to be combined
+---@return string path - the final combined path
+function filesystem.path(...) end
+
+--- Combines a variable amount of strings as paths together to one big path.
+--- Additionally, applies given conversion.
+---@param parameter FIN.Filesystem.PathParameters - defines a conversion that should get applied to the output path.
+---@param ... string - paths to be combined
+---@return string path - the final combined and converted output path
+function filesystem.path(parameter, ...) end
+
+---@alias FIN.Filesystem.PathRegister
+---|1 Is filesystem root
+---|2 Is Empty (includes if it is root-path)
+---|4 Is absolute path
+---|8 Is only a file/folder name
+---|16 Filename has extension
+---|32 Ends with a / → refers a directory
+
+--- Will be checked for lexical features.
+--- Return value which is a bit-flag-register describing those lexical features.
+---@param path string - filesystem-path you want to get lexical features from.
+---@return FIN.Filesystem.PathRegister BitRegister - bit-register describing the features of each path
+function filesystem.analyzePath(path) end
+
+--- Each string will be viewed as one filesystem-path and will be checked for lexical features.
+--- Each of those string will then have a integer return value which is a bit-flag-register describing those lexical features.
+---@param ... string - filesystem-paths you want to get lexical features from.
+---@return FIN.Filesystem.PathRegister ... - bit-registers describing the features of each path
+function filesystem.analyzePath(...) end
+
+--- For given string, returns a bool to tell if string is a valid node (file/folder) name.
+---@param node string - node-name you want to check.
+---@return boolean isNode - True if node is a valid node-name.
+function filesystem.isNode(node) end
+
+--- For each given string, returns a bool to tell if string is a valid node (file/folder) name.
+---@param ... string - node-names you want to check.
+---@return boolean ... - True if the corresponding string is a valid node-name.
+function filesystem.isNode(...) end
+)");
+	
+	const FString FINGenLuaSumnekoDocumentationEnd = FString::Printf(TEXT("%s\n%s\n%s\n%s\n%s\n"),
+		MiscDocumentation, EventApiDocumentation, ComponentApiDocumentation, ComputerApiDocumentation, FileSystemApiDocumentation);

--- a/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
+++ b/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
@@ -4,6 +4,13 @@
 inline const auto FINGenLuaSumnekoDocumentationStart = TEXT(R"(error("I don't know what your misson is. But is file is not meant to be executed in any way. It's a meta file.")
 ---@meta
 ---@diagnostic disable
+
+---@class FIN.classes
+local classes = {}
+
+---@class FIN.structs
+local structs = {}
+
 )");
 
 inline const auto MiscDocumentation = TEXT(R"(

--- a/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
+++ b/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
@@ -201,6 +201,10 @@ inline const auto ComputerApiDocumentation = TEXT(R"(
 ---@class FIN.Computer.Api
 computer = {}
 
+--- Media Subsystem
+---@type FIN.FINMediaSubsystem
+computer.media = nil
+
 --- Returns the current memory usage
 ---@return integer usage
 ---@return integer capacity

--- a/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
+++ b/Source/FicsItNetworks/Public/Utils/FINGenLuaDocSumneko.h
@@ -6,10 +6,10 @@ inline const auto FINGenLuaSumnekoDocumentationStart = TEXT(R"(error("I don't kn
 ---@diagnostic disable
 
 ---@class FIN.classes
-local classes = {}
+classes = {}
 
 ---@class FIN.structs
-local structs = {}
+structs = {}
 
 )");
 


### PR DESCRIPTION
`FINGenLuaDocSumneko` does the the samething as `FinGenLuaDoc` but for the Sumneko Language Server.

Also adds documentation for `computer`, `component`, `event`, `filesystem` and some other things.
The documentation for that is written by hand though to not modify any code. Since this is not asked for or talked about.

## Added Features
Adds `Signals` that are marked deprecated in order to give feedback to the user. Also gives you an usage example with every `Signal` which is customized to the `Signal`.

`FIN_Operator_*` are mapped to `---@operator *` this can though throw an exception if `FIN_Operator_*` is not supported (`FIN_Operator_Equals`, `FIN_Operator_LessThan`, `FIN_Operator_LessOrEqualThan`, `FIN_Operator_Index`, `FIN_Operator_NewIndex`), since there is no equivalent operator naming in sumneko, are also not used currently and only cause a game crash when executing the command (there for not game breaking).