### PR TITLE
Fix for newTimeTable crashing the game

### DIFF
--- a/Source/FicsItNetworks/Private/Reflection/FINStaticReflectionSource.cpp
+++ b/Source/FicsItNetworks/Private/Reflection/FINStaticReflectionSource.cpp
@@ -1785,7 +1785,7 @@ BeginFunc(getTimeTable, "Get Time Table", "Returns the timetable of this train."
 	Body()
 	timeTable = Ctx.GetTrace() / self->GetTimeTable();
 } EndFunc()
-BeginFunc(newTimeTable, "New Time Table", "Creates and returns a new timetable for this train.") {
+BeginFunc(newTimeTable, "New Time Table", "Creates and returns a new timetable for this train.", 0) {
 	OutVal(0, RTrace<AFGRailroadTimeTable>, timeTable, "Time Table", "The new timetable for this train.")
 	Body()
 	timeTable = Ctx.GetTrace() / self->NewTimeTable();


### PR DESCRIPTION
this will cause newTimeTable to return a future. If you depend on the return value, remeber to call the method with an additional :await() after
