### PR TITLE
Improve documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,16 @@
-FicsIt-Networks [![Build Status](https://jenkins.massivebytes.net/job/FicsIt-Networks/job/master/badge/icon)](https://jenkins.massivebytes.net/job/FicsIt-Networks/job/master)
-===============
-FicsIt-Networks is a mod for Satisfactory, written in C++/BP using Unreal Engine and the Satisfactory Modloader, which allows you to control, monitor, manage and automate each process of your factory by providing a network system and programmable computers, aswell as other I/O.
+# FicsIt-Networks
+
+FicsIt-Networks allows you to control, mointor, manage and automate each process of your factory by providing a network system and programmable computers, aswell as other I/O.
 It is inspired by [OpenComputers](https://github.com/MightyPirates/OpenComputers).
 
 **If you want to learn more:**
 [please visit the Documentation](https://docs.ficsit.app/ficsit-networks/latest)
 [or the SMR Mod page](https://ficsit.app/mod/8d8gk4imvFanRs)
 
-Discord
-=======
-You can join our [discord server](https://discord.gg/3VfZ6Da) where you can get help for using the mod, where you can share your scripts or just simply discuss the mod.
+<a href="https://discord.gg/3VfZ6Da"><img height="50px" src="https://gotpa.ws/img/join_discord.png" /></a>
 
-Work In Progress
-================
-This project is in no finished state!
-We are constantly working on features to make the mod even greater.
+## Development Versions
 
-Want to test the Mod?
-=====================
 If you want to test the mod and so help with development,
 we would reccomend you to join the [FicsIt-Networks Discord Server](https://discord.gg/3VfZ6Da) and contact one of the mod developers for a more in depth help.
 Testing means, it would not be a good idea to use the mod in your normal game state,
@@ -25,84 +18,45 @@ testing means testing the mod in its own world to make sure every features works
 
 You can download the latest builds:
 
-[ [Latest Stable Version](https://jenkins.massivebytes.net/job/FicsIt-Networks/job/master/) ] 
-[ [Development Version](https://jenkins.massivebytes.net/job/FicsIt-Networks/job/development/) ]
+[ [Latest Stable Version](https://github.com/Panakotta00/FicsIt-Networks/releases/latest) ] 
+[ [Development Versions](https://github.com/Panakotta00/FicsIt-Networks/actions?query=branch%3Adevelopment) ]
 
-To install it, simply download the .zip artifact and extract the contents of it into the `<sf installation>/FactoryGame/Mods/FicsItNetworks` folder.
+To install it, simply download the `FicsItNetworks-Windows.zip` artifact and extract the contents of it into the `<sf installation>/FactoryGame/Mods/FicsItNetworks` folder.
 It has to be this exact path and folder name! Extract it in a way, so the `.uplugin`-File is located within this folder.
 
-Streams
-=======
-The biggest part of making this mod gets streamed at [Panakotta00's Twitch Channel](https://twitch.tv/panakotta00).
+## Features
 
-You-Tube
-========
-- [Release Trailer](https://www.youtube.com/watch?v=EErI0OiWttw)
-- [Mod Showcase by RandomGamer](https://www.youtube.com/watch?v=EtybEOkgJ4o)
-- [Tutorial Series](https://www.youtube.com/playlist?list=PLKTdAeAt_BilFGjKoIG9GObwjqmxdSoeE)
-- [Lua Tutorial Series](https://www.youtube.com/playlist?list=PLKTdAeAt_BimxLkH05GSNBZpydxc553hE)
+- **Networks**  
+This is a basic network like the existing power network allowing you to connect buildings with a network connector to the network.
+When placing a network cable you're also able to automatically add a network adapter to existing Satisfactory Machines to connect them to the network.
+These networks then allow you to access function from machines and get automatically send signals from machines e.g. no need of polling.
+- **Modular Computer**  
+The modular computer is a building wich has  network connector and a power connector.
+The basic concept is, that you have panele were you can place different modules like the cpu, ram-bars or a drive enabling different features for your computer.
+There is currently one type of processor, the Lua Processor. It allows you to run complex Lua code which uses the network to interact with your factory.
+- **Modular I/O Panels**  
+The modular I/O Panel is basically a control panel were you can attach different I/O modules like buttons, levers, LEDs, displays and so on. To read and write data to and from a computer.
+- **Screens**  
+Monitors/Monitors and GPUs allow you to visualize data in multiple different forms. They also allow you to use montiors as user inputs like Keyboard, Mouse and Touch.
+- **Extensive API**  
+Most of the games mechanics are exposed to the script environment using the reflection system. The in-game reflection viewer allows you to easily discover exposed functionallity for every machine and most buildings. Even other mods that do not explicity support FicsIt-Networks have some API available to work with.
+- **Lua Scripting**  
+Lua is a first-class-citizen and is used to programm in-game computers. The reflection system and even more API is exposed to the Lua runtime giving you a lot of freedom on how to control your factory.
 
-Features
-========
-- Networks
-  This is a basic network like the existing power network allowing you to connect buildings with a network connector to the network.
-  When placing a network cable you're also able to automatically add a network adapter to existing Satisfactory Machines to connect them to the network.
-  These networks then allow you to access function from machines and get automatically send signals from machines e.g. no need of polling.
-- Modular Computer
-  The modular computer is a building wich has  network connector and a power connector.
-  The basic concept is, that you have panele were you can place different modules like the cpu, ram-bars or a drive enabling different features for your computer.
-  There is currently one type of processor, the Lua Processor. It allows you to run complex Lua code which uses the network to interact with your factory.
-- Modular I/O Panel
-  The modular I/O Panel is basically a control panel were you can attach different I/O modules like buttons, levers, LEDs, displays and so on. To read and write data to and from a computer.
-- File Systems
-  You can read and write files to and from a virtual file system in f.e. a hard drive which you can connect to a computer by the drive holder computer module.
-- Speakers
-  With the Speaker-Pole you can play custom sound files ingame on command. So you can alert the player automatically when f.e. the Iron stock runs low.
-- Codeable Splitters/Mergers
-  There are also Splitters and Mergers able to connect to the network allowing you to fully customize their behaviour by controlling each step from a computer via. f.e. a lua code.
-- Power Controller
-  The Power Controller Pole is basically a smart power switch allowing you to connect and disconnect two different power networks.
-- Network Adapter
-  The network adapter allows you to connect any satisfactory machine to the network and allow some basic and some more complex interactions like reading inventories.
-- Monitors & GPUs
-  Monitors and GPUs allow you to visualize data in multiple different forms. They also allow you to use montiors as user inputs like Keyboard, Mouse and Touch.
-- Vehicle Scanner
-  Allows to interact with vehicles that pass over it. It also looks nice ;-)
-- Reflection System
-  The Reflection System allows to check data-types, functions, properties, signals and more. You can look up all sort of information and it helps you
-  for a more dynamic way to interact with the machines. This system also provides a abstraction layer so that further language implementations and such can get implemented more
-  easily and quicker. It also provides a dependency-less system so other mods can provide functionality that can be used by ficsit-networks.
-  It also provides the reflection viewer which is UI Widget allowing you to browse and explore the reflection data, like an ingame documentation.
-- Internet Card
-  The Internet Card allows you to connect to the internet so you can do f.e. http requests and download
-  custom user made scripts from f.e. gist or pastebin. But you can use it in anyway, like talking to an REST API.
-- Wireless Networks
-  You can broaden your horizons with Wireless Access Points which connect to already built Radar Towers and allow wireless communications over long distances.
+## Build from Scratch
+1. Setup the Mod-Development Environment for Satisfactory Modding. More info can be found in the [SMR Docs](https://docs.ficsit.app/satisfactory-modding/latest/Development/BeginnersGuide/index.html).
+2. Now you have to clone this repository **recursively** into the Mods folder of the [Satisfactory Modloader](https://github.com/satisfactorymodding/SatisfactoryModLoader) repository folder you cloned in the setup process.
+3. Apply the `SML_Patch.patch` file using `git apply` to the Satisfactory Modloader Repository folder. This will add simple changes to the header files that are necessary for FicsIt-Networks to build properly.
+4. Now you can build FicsIt-Networks like any other Satisfactory Mod using your build tool of choice or Alpakit.
 
-Dependencies
-============
-For using the mod there are no dependencies except the [Satisfactory Modloader](https://github.com/satisfactorymodding/SatisfactoryModLoader) for the game version and mod version you want to use.
+FicsIt-Networks relies on a slightly custom version of Eris for Lua 5.4 to run Lua code and persistency. The changes only apply to C++ compiler support and persistency adjustments. The dependency will be built together with the normal mod, so you only have to ensure the submodule is cloned properly.
 
-As general project build dependency we have Eris for Lua 5.3 to run Lua code and persistency.
-
-Roadmap
-=======
-You can find the detailed progress in the [project board](https://github.com/CoderDE/FicsIt-Networks/projects/1).
-
-- add new sensors (like player sensors)
-- microcontrollers
-- computer power consumption
-- adding support for a visual scripting language
-- port the mod to official mod kit (when released)
-(the list is dynamic and gets updated based on new ideas)
-
-Contributors
-============
-- [Panakotta00](https://panakotta00.massivebytes.net)
+## Contributors
+- [Panakotta00](https://panakotta00.dev)
+- [Roze](https://github.com/RozeDoyanawa)
 - [RosszEmber](https://www.deviantart.com/ronsemberg)
 - Deantendo
 - Coffeediction
-- [Roze](https://github.com/RozeDoyanawa)
 - [Raysh](https://www.artstation.com/raysh)
 - Esper
 - [leonardfactory](https://github.com/rockfactory)

--- a/Source/FicsItNetworksComputer/Public/ComputerModules/PCI/FINComputerGPUT2.h
+++ b/Source/FicsItNetworksComputer/Public/ComputerModules/PCI/FINComputerGPUT2.h
@@ -570,7 +570,7 @@ public:
 		ParameterInternalNames.Add("startDirections");
 		ParameterDisplayNames.Add(FText::FromString("Start Direction"));
 		ParameterDescriptions.Add(FText::FromString("The direction of the spline of how it exists the start point."));
-		ParameterInternalNames.Add("end");
+		ParameterInternalNames.Add("end_");
 		ParameterDisplayNames.Add(FText::FromString("End"));
 		ParameterDescriptions.Add(FText::FromString("The local position of the end point of the spline."));
 		ParameterInternalNames.Add("endDirection");

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaComputerAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaComputerAPI.cpp
@@ -30,12 +30,12 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		(int, string, string)		magicTime()
+			 * @LuaFunction		(integer, string, string)		magicTime()
 			 * @DisplayName		Magic Time
 			 *
 			 * Returns some kind of strange/mysterious time data from a unknown place (the real life).
 			 *
-			 * @return	unix			int		Unix			Unix Timestamp
+			 * @return	unix			integer	Unix			Unix Timestamp
 			 * @return	cultureTime		string	Culture Time	The time as text with the culture format used by the Host
 			 * @return	iso8601			string	ISO 8601		The time as a Date-Time-Stamp after ISO 8601
 			 */)", magicTime) {

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaDebugAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaDebugAPI.cpp
@@ -19,7 +19,7 @@ namespace FINLua {
 			 *
 			 * Allows to log the given strings to the Game Log.
 			 *
-			 * @param	msgs	string...	A list of log messages that should get printed to the game console.
+			 * @param		...			string		Messages	A list of log messages that should get printed to the game console.
 			 */)", log) {
 				int args = lua_gettop(L);
 				FString Msg;
@@ -43,6 +43,31 @@ namespace FINLua {
 			 * Check https://www.lua.org/manual/5.4/manual.html#pdf-debug.traceback[the Lua Manual] for more information.
 			 */)", traceback) { return 0; }
 		}
+
+		// TODO: how to properly document xpcall? Uncommenting this code crashes the game on loading a save.
+		//LuaModuleGlobalBareValue(R"(/**
+		// * @LuaGlobal		xpcall	fun(fn, ...): (ok: boolean, err: { message: any, trace: string }?)
+		// * @DisplayName		XPcall
+		// *
+		// * Ficsit networks ships with a slightly modifier version of `xpcall`. Like `pcall`, it accepts a function
+		// * and its arguments, calls it and checks whether an error has occurred.
+		// *
+		// * It returns a boolean indicating that the function call was successful.
+		// * If the call fails, it also returns a table with two fields: `message` is an error message
+		// * (or whatever was passed to an `error` call), and `trace` is a string with traceback.
+		// *
+		// * If the call was successful, our version of xpcall doesn't return its result.
+		// * To get it, pass in a closure that will set a local variable:
+		// *
+		// * [source,lua]
+		// * ---
+		// * local result
+		// * local ok, err = xpcall(function() result = doSomething() end)
+		// * ---
+		// */)", xpcall) {
+		//	// This function is here for documentation purposes only;
+		//	// The actual implementation is in LuaBaseModule.cpp
+		//}
 
 		LuaModulePostSetup() {
 			lua_getglobal(L, "debug");

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaDebugAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaDebugAPI.cpp
@@ -44,31 +44,6 @@ namespace FINLua {
 			 */)", traceback) { return 0; }
 		}
 
-		// TODO: how to properly document xpcall? Uncommenting this code crashes the game on loading a save.
-		//LuaModuleGlobalBareValue(R"(/**
-		// * @LuaGlobal		xpcall	fun(fn, ...): (ok: boolean, err: { message: any, trace: string }?)
-		// * @DisplayName		XPcall
-		// *
-		// * Ficsit networks ships with a slightly modifier version of `xpcall`. Like `pcall`, it accepts a function
-		// * and its arguments, calls it and checks whether an error has occurred.
-		// *
-		// * It returns a boolean indicating that the function call was successful.
-		// * If the call fails, it also returns a table with two fields: `message` is an error message
-		// * (or whatever was passed to an `error` call), and `trace` is a string with traceback.
-		// *
-		// * If the call was successful, our version of xpcall doesn't return its result.
-		// * To get it, pass in a closure that will set a local variable:
-		// *
-		// * [source,lua]
-		// * ---
-		// * local result
-		// * local ok, err = xpcall(function() result = doSomething() end)
-		// * ---
-		// */)", xpcall) {
-		//	// This function is here for documentation purposes only;
-		//	// The actual implementation is in LuaBaseModule.cpp
-		//}
-
 		LuaModulePostSetup() {
 			lua_getglobal(L, "debug");
 			lua_pushcfunction(L, luaopen_debug);

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaFileSystemAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaFileSystemAPI.cpp
@@ -115,14 +115,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	createDir(path: string, recursive: bool)
+			 * @LuaFunction		boolean	createDir(path: string, recursive: bool)
 			 * @DisplayName		Create Directory
 			 *
 			 * Creates the folder path.
 			 *
 			 * @parameter	path		string	Path		folder path the function should create
-			 * @parameter	recursive	bool	Recursive	If false creates only the last folder of the path. If true creates all folders in the path.
-			 * @return		success		bool	Success		Returns true if it was able to create the directory.
+			 * @parameter	recursive	boolean	Recursive	If false creates only the last folder of the path. If true creates all folders in the path.
+			 * @return		success		boolean	Success		Returns true if it was able to create the directory.
 			 */)", createDir) {
 				LuaFunc();
 
@@ -135,14 +135,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	remove(path: string, recursive: bool)
+			 * @LuaFunction		boolean	remove(path: string, recursive: bool)
 			 * @DisplayName		Remove
 			 *
 			 * Removes the filesystem object at the given path.
 			 *
 			 * @parameter	path		string	Path		path to the filesystem object
-			 * @parameter	recusive	bool	Recursive	If false only removes the given filesystem object. If true removes all childs of the filesystem object.
-			 * @return		success		bool	Success		Returns true if it was able to remove the node
+			 * @parameter	recusive	boolean	Recursive	If false only removes the given filesystem object. If true removes all childs of the filesystem object.
+			 * @return		success		boolean	Success		Returns true if it was able to remove the node
 			 */)", remove) {
 				LuaFunc();
 
@@ -155,7 +155,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	move(from: string, to: string)
+			 * @LuaFunction		boolean	move(from: string, to: string)
 			 * @DisplayName		Move
 			 *
 			 * Moves the filesystem object from the given path to the other given path.
@@ -164,7 +164,7 @@ namespace FINLua {
 			 *
 			 * @parameter	from		string	From		path to the filesystem object you want to move
 			 * @parameter	to			string	To			path to the filesystem object the target should get moved to
-			 * @return		success		bool	Success		returns true if it was able to move the node
+			 * @return		success		boolean	Success		returns true if it was able to move the node
 			 */)", move) {
 				LuaFunc();
 
@@ -177,14 +177,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	rename(path: string, name: string)
+			 * @LuaFunction		boolean	rename(path: string, name: string)
 			 * @DisplayName		Rename
 			 *
 			 * Renames the filesystem object at the given path to the given name.
 			 *
 			 * @parameter	path		string	Path		path to the filesystem object you want to rename
 			 * @parameter	name		string	Name		the new name for your filesystem object
-			 * @return		success		bool	Success		returns true if it was able to rename the node
+			 * @return		success		boolean	Success		returns true if it was able to rename the node
 			 */)", rename) {
 				LuaFunc();
 
@@ -197,10 +197,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	exists(path: string)
+			 * @LuaFunction		boolean	exists(path: string)
 			 * @DisplayName		Exists
 			 *
 			 * Returns true if the given path exists.
+			 * 
+			 * @parameter	path		string	Path		path to the filesystem object you want to check
+			 * @return		exists		boolean	Exists		returns true if the given file exists
 			 */)", exists) {
 				LuaFunc();
 
@@ -215,7 +218,10 @@ namespace FINLua {
 			 * @LuaFunction		string[]	children(path: string)
 			 * @DisplayName		Children
 			 *
-			 * Lists all children names of the node with the given path. (f.e. items in a folder)
+			 * Lists all children names of the node with the given path. (i.e. items in a folder)
+			 *
+			 * @parameter	path		string		Path		path to the filesystem object you want to list
+			 * @return		children	string[]	Children	file names of children
 			 */)", children) {
 				LuaFunc();
 
@@ -234,10 +240,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	isFile(path: string)
+			 * @LuaFunction		boolean		isFile(path: string)
 			 * @DisplayName		Is File
 			 *
 			 * Returns true if the given path refers to a file.
+			 *
+			 * @parameter	path		string	Path		path to the filesystem object you want to check
+			 * @return		isFile		boolean	Is file		returns true if the given path refers to a file
 			 */)", isFile) {
 				LuaFunc();
 				const auto path = CodersFileSystem::Path(luaL_checkstring(L, 1));
@@ -248,10 +257,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	isDir(path: string)
+			 * @LuaFunction		boolean		isDir(path: string)
 			 * @DisplayName		Is Dir
 			 *
 			 * Returns true if the given path refers to directory.
+			 *
+			 * @parameter	path		string	Path		path to the filesystem object you want to check
+			 * @return		isDir		boolean	Is dir		returns true if the given path refers to a directory
 			 */)", isDir) {
 				LuaFunc();
 				const auto path = CodersFileSystem::Path(luaL_checkstring(L, 1));
@@ -262,14 +274,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	mount(device: string, mountPoint: string)
+			 * @LuaFunction		boolean		mount(device: string, mountPoint: string)
 			 * @DisplayName		Mount
 			 *
 			 * This function mounts the device referenced by the the path to a device node to the given mount point.
 			 *
 			 * @parameter	device		string	Device			the path to the device you want to mount
 			 * @parameter	mountPoint	string	Mount Point		the path to the point were the device should get mounted to
-			 * @return		success		bool	Success			true if the mount was executed successfully
+			 * @return		success		boolean	Success			true if the mount was executed successfully
 			 */)", mount) {
 				LuaFunc();
 				const auto devPath = CodersFileSystem::Path(luaL_checkstring(L, 1));
@@ -286,13 +298,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	unmount(mountPoint: string)
+			 * @LuaFunction		boolean		unmount(mountPoint: string)
 			 * @DisplayName		Un-Mount
 			 *
 			 * This function unmounts if the device at the given mount point.
 			 *
 			 * @parameter	mountPoint	string	Mount Point		the path the device is mounted to
-			 * @return		success		bool	Success			returns true if it was able to unmount the device located at the mount point
+			 * @return		success		boolean	Success			returns true if it was able to unmount the device located at the mount point
 			 */)", unmount) {
 				LuaFunc();
 				const auto mountPath = CodersFileSystem::Path(luaL_checkstring(L, 1));
@@ -314,7 +326,10 @@ namespace FINLua {
 			 *
 			 * Function fails if path doesn’t exist or path doesn’t refer to a file.
 			 *
-			 * Returns the result of the execute function or what ever it yielded
+			 * Returns the result of the execute function or what ever it yielded.
+			 *
+			 * @parameter	path		string	Path		path to the filesystem object you want to execute
+			 * @return		...			any		Results		the result of the execute function or what ever it yielded
 			 */)", doFile) {
 				LuaFunc();
 
@@ -337,11 +352,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		function	loadFile(path: string)
+			 * @LuaFunction		fun(): ...		loadFile(path: string)
 			 * @DisplayName		Load File
 			 *
 			 * Loads the file refered by the given path as a Lua function and returns it.
 			 * Functions fails if path doesn’t exist or path doesn’t reger to a file.
+			 *
+			 * @parameter	path		string			Path		path to the filesystem object you want to load
+			 * @return		code		fun(): ...		Code		a function that runs the loaded code
 			 */)", loadFile) {
 				LuaFunc();
 
@@ -364,7 +382,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		string	path([int,] string...)
+			 * @LuaFunction		string	path([conversion: integer,] ...: string)
 			 * @DisplayName		Path
 			 *
 			 * Combines a variable amount of strings as paths together to one big path.
@@ -393,6 +411,10 @@ namespace FINLua {
 			 *       `/path/to/file.` -> `.`
 			 * |===
 			 * ====
+			 *
+			 * @parameter	conversion	integer|string		Conversion		Conversion that will be applied to paths
+			 * @parameter	...			string				Paths			Paths that will be joined
+			 * @return		result		string				Result			Joined and processed path
 			 */)", path) {
 				LuaFunc();
 
@@ -432,7 +454,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		int...	analyzePath(string...)
+			 * @LuaFunction		...		analyzePath(...: string)
 			 * @DisplayName		Analyze Path
 			 *
 			 * Each provided string will be viewed as one filesystem-path and will be checked for lexical features. +
@@ -451,6 +473,9 @@ namespace FINLua {
 			 * | 6 | Ends with a `/` -> refers a directory
 			 * |===
 			 * ====
+			 *
+			 * @parameter	...			string				Paths			Paths that will be analyzed
+			 * @return		...			integer				Results			Analysis results
 			 */)", analyzePath) {
 				LuaFunc();
 
@@ -470,10 +495,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool...		isNode(string...)
+			 * @LuaFunction		...		isNode(...: string)
 			 * @DisplayName		Is Node
 			 *
 			 * For each given string, returns a bool to tell if string is a valid node (file/folder) name.
+			 *
+			 * @parameter	...			string				Paths			Paths that will be checked
+			 * @return		...			boolean				Results			True if path is a valid node (file/folder) name
 			 */)", isNode) {
 				LuaFunc();
 				int args = lua_gettop(L);
@@ -484,7 +512,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		string...	meta(string...)
+			 * @LuaFunction		...		meta(...: string)
 			 * @DisplayName		Meta
 			 *
 			 * Returns for each given string path, a table that defines contains some meta information about node the string references.
@@ -500,6 +528,9 @@ namespace FINLua {
 			 * | `Unknown`		| The node type is not known to this utility function.
 			 * | ===
 			 * ====
+			 *
+			 * @parameter	...			string				Paths			Paths that will be checked
+			 * @return		...			{type:string}		Results			Metadata for each path
 			 */)", meta) {
 				LuaFunc();
 
@@ -540,6 +571,8 @@ namespace FINLua {
 			 * @DisplayName		Close
 			 *
 			 * Closes the File-Stream.
+			 *
+			 * @parameter	self	File
 			 */)", close) {
 				LuaFileFunc();
 
@@ -550,10 +583,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		write(string...)
+			 * @LuaFunction		write(... string)
 			 * @DisplayName		Write
 			 *
 			 * Writes the given strings to the File-Stream.
+			 *
+			 * @parameter	self	File
+			 * @parameter	...		string		Strings		Strings that will be written to the stream
 			 */)", write) {
 				LuaFileFunc();
 
@@ -569,11 +605,15 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		string...	read(int...)
+			 * @LuaFunction		...		read(...: integer)
 			 * @DisplayName		Read
 			 *
 			 * Reads up to the given amount of bytes from the file.
 			 * Strings may be smaller than the given amount of bytes due to f.e. reaching the End-Of-File.
+			 *
+			 * @parameter	self	File
+			 * @parameter	...		integer		Sizes		Maximum sizes of strings
+			 * @return		...		string?		Contents	Contents of the file
 			 */)", read) {
 				LuaFileFunc();
 
@@ -592,7 +632,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		int		seek(where: string, offset: int)
+			 * @LuaFunction		integer		seek(where: string, offset: integer)
 			 * @DisplayName		Seek
 			 *
 			 * Moves the File-Streams pointer to a position defined by the offset and from what starting location.
@@ -604,6 +644,11 @@ namespace FINLua {
 			 * * `set` Offset is relative to the beginning of the file
 			 * * `end` Offset is relative to the end of the file
 			 * ====
+			 *
+			 * @parameter	self	File
+			 * @parameter	where		string		Where		Starting location
+			 * @parameter	offset		integer		Offset		Offset
+			 * @return		position	string?		Position	Current position in the file
 			 */)", seek) {
 				LuaFileFunc();
 

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaKernelAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaKernelAPI.cpp
@@ -26,14 +26,14 @@ namespace FINLua {
 		 * @DisplayName		File-System Library
 		 */)", filesystem) {
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	initFileSystem(path: string)
+			 * @LuaFunction		boolean	initFileSystem(path: string)
 			 * @DisplayName		Init File-System
 			 *
 			 * Trys to mount the system DevDevice to the given location.
 			 * The DevDevice is special Device holding DeviceNodes for all filesystems added to the system. (like TmpFS and drives). It is unmountable as well as getting mounted a seccond time.
 			 *
-			 * @parameter	path		string	Path		path to the mountpoint were the dev device should get mounted to
-			 * @return		success		bool	Success		returns if it was able to mount the DevDevice
+			 * @parameter	path		string		Path		path to the mountpoint were the dev device should get mounted to
+			 * @return		success		boolean		Success		returns if it was able to mount the DevDevice
 			 */)", initFileSystem) {
 				UFINKernelSystem* kernel = FINLua::luaFIN_getKernel(L);
 				FLuaSync SyncCall(L);
@@ -44,7 +44,7 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	makeFileSystem(type: string, name: string)
+			 * @LuaFunction		boolean	makeFileSystem(type: string, name: string)
 			 * @DisplayName		Make File-System
 			 *
 			 * Trys to create a new file system of the given type with the given name.
@@ -58,9 +58,9 @@ namespace FINLua {
 			 * A temporary filesystem only existing at runtime in the memory of your computer. All data will be lost when the system stops.
 			 * ====
 			 *
-			 * @parameter	type		string	Type		the type of the new filesystem
-			 * @parameter	name		string	Name		the name of the new filesystem you want to create
-			 * @return		success		bool	Success		returns true if it was able to create the new filesystem
+			 * @parameter	type		string		Type		the type of the new filesystem
+			 * @parameter	name		string		Name		the name of the new filesystem you want to create
+			 * @return		success		boolean		Success		returns true if it was able to create the new filesystem
 			 */)", makeFileSystem) {
 				UFINKernelSystem* kernel = FINLua::luaFIN_getKernel(L);
 				FINLua::FLuaSync SyncCall(L);
@@ -80,14 +80,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	removeFileSystem(name: string)
+			 * @LuaFunction		boolean	removeFileSystem(name: string)
 			 * @DisplayName		Remove File-System
 			 *
 			 * Tries to remove the filesystem with the given name from the system DevDevice.
 			 * All mounts of the device will run invalid.
 			 *
-			 * @parameter	name		string	Name		the name of the new filesystem you want to remove
-			 * @return		success		bool	Success		returns true if it was able to remove the new filesystem
+			 * @parameter	name		string		Name		the name of the new filesystem you want to remove
+			 * @return		success		boolean		Success		returns true if it was able to remove the new filesystem
 			 */)", removeFileSystem) {
 				UFINKernelSystem* kernel = FINLua::luaFIN_getKernel(L);
 				FLuaSync SyncCall(L);
@@ -119,13 +119,13 @@ namespace FINLua {
 		 * @DisplayName		Computer Library
 		 */)", computer) {
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		(usage: int, capacity: int)	getMemory()
+			 * @LuaFunction		(usage: integer, capacity: integer)	getMemory()
 			 * @DisplayName		Get Memory
 			 *
 			 * Returns the used memory and memory capacity the computer has.
 			 *
-			 * @return	usage		int		Usage		The memory usage at the current time
-			 * @return	capacity	int		Capacity	The memory capacity the computer has
+			 * @return	usage		integer		Usage		The memory usage at the current time
+			 * @return	capacity	integer		Capacity	The memory capacity the computer has
 			 */)", getMemory) {
 				FINLua::FLuaSync sync(L);
 
@@ -147,7 +147,7 @@ namespace FINLua {
 			 *
 			 * Returns a reference to the computer case in which the current code is running.
 			 *
-			 * @return	case	ComputerCase	The computer case this lua runtime is running in.
+			 * @return	case	ComputerCase	Case	The computer case this lua runtime is running in
 			 */)", getInstance) {
 				FLuaSync sync(L);
 
@@ -159,14 +159,14 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		Object[]	getPCIDevices([type: Class])
+			 * @LuaFunction		Object[]	getPCIDevices(type: Object-Class?)
 			 * @DisplayName		Get PCI-Devices
 			 *
 			 * This function allows you to get all installed https://docs.ficsit.app/ficsit-networks/latest/buildings/ComputerCase/index.html#_pci_interface[PCI-Devices] in a computer of a given type.
 			 * Have a look at https://docs.ficsit.app/ficsit-networks/latest/lua/examples/PCIDevices.html[this] example to fully understand how it works.
 			 *
-			 * @parameter	type		Class		Type		Optional type which will be used to filter all PCI-Devices. If not provided, will return all PCI-Devices.
-			 * @return		objects		Object[]	Objects		An array containing instances for each PCI-Device built into the computer.
+			 * @parameter	type		Object-Class?	Type		Optional type which will be used to filter all PCI-Devices. If not provided, will return all PCI-Devices
+			 * @return		objects		Object[]		Objects		An array containing instances for each PCI-Device built into the computer
 			 */)", getPCIDevices) {
 				FLuaSync sync(L);
 
@@ -203,12 +203,12 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		int		millis()
+			 * @LuaFunction		integer		millis()
 			 * @DisplayName		Millis
 			 *
 			 * Returns the amount of milliseconds passed since the system started.
 			 *
-			 * @return	millis	int		The amount of real milliseconds sinde the ingame-computer started.
+			 * @return	millis	integer		Millis		The amount of real milliseconds sinde the ingame-computer started
 			 */)", millis) {
 				FLuaSync sync(L);
 
@@ -236,7 +236,7 @@ namespace FINLua {
 			 * @LuaFunction		stop()
 			 * @DisplayName		Stop
 			 *
-			 * Stops the current code execution. +
+			 * Stops the current code execution.
 			 * Basically kills the PC runtime immediately.
 			 */)", stop) {
 				FFINLuaRuntime& runtime = luaFIN_getRuntime(L);
@@ -254,7 +254,7 @@ namespace FINLua {
 			 *
 			 * Sets the code of the current eeprom. Doesn’t cause a system reset.
 			 *
-			 * @param	code	string	The new EEPROM Code as string.
+			 * @parameter	code	string		Code	The new EEPROM Code as string
 			 */)", setEEPROM) {
 				FLuaSync sync(L);
 
@@ -280,7 +280,7 @@ namespace FINLua {
 			 *
 			 * Returns the current eeprom contents.
 			 *
-			 * @return	code	string	The EEPROM Code as string.
+			 * @return	code	string		Code	The EEPROM Code as string
 			 */)", getEEPROM) {
 				FLuaSync sync(L);
 
@@ -298,7 +298,7 @@ namespace FINLua {
 			 *
 			 * Lets the computer emit a simple beep sound with the given pitch.
 			 *
-			 * @param	pitch	number	a multiplier for the pitch adjustment of the beep sound.
+			 * @parameter	pitch	number		Pitch	a multiplier for the pitch adjustment of the beep sound
 			 */)", beep) {
 				FLuaSync sync(L);
 
@@ -317,6 +317,8 @@ namespace FINLua {
 			 * @DisplayName		Panic
 			 *
 			 * Crashes the computer with the given error message.
+			 *
+			 * @parameter	error	string		Error	an error message
 			 */)", panic) {
 				luaL_checkstring(L, -1);
 				UFINKernelSystem* kernel = luaFIN_getKernel(L);

--- a/Source/FicsItNetworksLua/Private/FINLua/API/LuaWorldAPI.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/API/LuaWorldAPI.cpp
@@ -21,13 +21,13 @@ namespace FINLua {
 		 * @LuaLibrary		computer
 		 */)", computer) {
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		textNotification(text: string, username: string)
+			 * @LuaFunction		textNotification(text: string, username: string?)
 			 * @DisplayName		Text Notification
 			 *
 			 * This function allows you to prompt a user with the given username, with a text message.
 			 *
 			 * @parameter	text		string	Text		The Text you want to send as Notification to the user
-			 * @parameter	username	string	Username	The username of the user you want to send the notification to
+			 * @parameter	username	string?	Username	The username of the user you want to send the notification to
 			 */)", textNotification) {
 				FLuaSync sync(L);
 
@@ -56,13 +56,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		attentionPing(position: Vector, [username: string])
+			 * @LuaFunction		attentionPing(position: Vector, username: string?)
 			 * @DisplayName		Attention Ping
 			 *
 			 * Allows to send a World Marker/Attention Ping for all or the given user.
 			 *
-			 * @parameter	position	Struct<FVector>		Position	The position in the world where the ping should occur
-			 * @parameter	username	string				Username	The username of the user you want to ping.
+			 * @parameter	position	Vector			Position	The position in the world where the ping should occur
+			* @parameter	username	string?			Username	The username of the user you want to ping
 			 */)", attentionPing) {
 				FLuaSync sync(L);
 
@@ -94,7 +94,7 @@ namespace FINLua {
 			 *
 			 * Returns the number of game seconds passed since the save got created. A game day consists of 24 game hours, a game hour consists of 60 game minutes, a game minute consists of 60 game seconds.
 			 *
-			 * @return	time	number	The current number of game seconds passed since the creation of the save.
+			 * @return	time	number		Time	The current number of game seconds passed since the creation of the save.
 			 */)", time) {
 				FLuaSync sync(L);
 

--- a/Source/FicsItNetworksLua/Private/FINLua/LuaMiscModules.cpp
+++ b/Source/FicsItNetworksLua/Private/FINLua/LuaMiscModules.cpp
@@ -44,13 +44,13 @@ namespace FINLua {
 			}
 
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		bool	isPromoted()
+			 * @LuaFunction		boolean	isPromoted()
 			 * @DisplayName		Is Promoted
 			 *
 			 * Returns true if the Lua runtime is currently promoted/elevated.
 			 * Which means its running in an seperate game thread allowing for fast bulk calculations.
 			 *
-			 * @return	isPromoted	bool	True if the currenty runtime is running in promoted/elevated tick state.
+			 * @return		promoted	boolean		Promoted	True if the currenty runtime is running in promoted/elevated tick state.
 			 */)", isPromoted) {
 				FFINLuaThreadedRuntime& runtime = luaFIN_getThreadedRuntime(L);
 				lua_pushboolean(L, runtime.ShouldBePromoted());
@@ -79,7 +79,7 @@ namespace FINLua {
 			return 0;
 		}
 		LuaModuleGlobalBareValue(R"(/**
-		 * @LuaGlobal		print	function(string...)
+		 * @LuaGlobal		print	fun(...)
 		 * @DisplayName		Print
 		 */)", print) {
 			lua_pushcfunction(L, luaPrint);
@@ -93,13 +93,13 @@ namespace FINLua {
 		 * The Computer Library provides functions for interaction with the computer and especially the Lua Runtime.
 		 */)", computer) {
 			LuaModuleTableFunction(R"(/**
-			 * @LuaFunction		log(verbosity: int, message: string)
+			 * @LuaFunction		log(verbosity: integer, message: string)
 			 * @DisplayName		Log
 			 *
 			 * Allows you to print a log message to the computers log with the given log verbosity.
 			 *
-			 * @parameter	verbosity	int		Verbosity	The log-level/verbosity of the message you want to log. 0 = Debug, 1 = Info, 2 = Warning, 3 = Error & 4 = Fatal
-			 * @parameter	message		string	Message		The log message you want to print
+			 * @parameter	verbosity	integer		Verbosity	The log-level/verbosity of the message you want to log. 0 = Debug, 1 = Info, 2 = Warning, 3 = Error & 4 = Fatal
+			 * @parameter	message		string		Message		The log message you want to print
 			 */)", log) {
 				FLuaSync sync(L);
 


### PR DESCRIPTION
Some improvements to documentation and `FINGenLuaDoc` output:

- added proper `@parameter`/`@return` annotations for all APIs in `Source/FicsItNetworksLua/`,
- fixed types in documentation (`int`->`integer`, etc.);
- dropped `@type` annotations from functions because sumneko language server doesn't handle them well;
- updated `FINGenLuaDoc::WriteFuture` not to use `@type` annotations as well;
- functions that return futures got `@nodiscard` annotation.