### PR TITLE
Set proper runtime values for struct properties

### DIFF
--- a/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Base.cpp
+++ b/Source/FicsItReflection/Private/Reflection/Source/Static/FIRSourceStatic_Base.cpp
@@ -145,40 +145,40 @@ BeginProp(RTrace<AActor>, owner, "Owner", "The parent actor of which this compon
 EndClass()
 
 BeginStructConstructable(FVector2D, "Vector2D", "Vector 2D", "Contains two cordinates (X, Y) to describe a position or movement vector in 2D Space")
-BeginProp(RFloat, x, "X", "The X coordinate component") {
+BeginProp(RFloat, x, "X", "The X coordinate component", 2) {
 	FIRReturn self->X;
 } PropSet() {
 	self->X = Val;
 } EndProp()
-BeginProp(RFloat, y, "Y", "The Y coordinate component") {
+BeginProp(RFloat, y, "Y", "The Y coordinate component", 2) {
 	FIRReturn self->Y;
 } PropSet() {
 	self->Y = Val;
 } EndProp()
-BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.") {
+BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.", 2) {
 	InVal(0, RStruct<FVector2D>, other, "Other", "The other vector that should be added to this vector")
 	OutVal(1, RStruct<FVector2D>, result, "Result", "The resulting vector of the vector addition")
 	Body()
 	result = (FIRStruct)(*self + other);
 } EndFunc()
-BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.") {
+BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.", 2) {
 	InVal(0, RStruct<FVector2D>, other, "Other", "The other vector that should be subtracted from this vector")
 	OutVal(1, RStruct<FVector2D>, result, "Result", "The resulting vector of the vector subtraction")
 	Body()
 	result = (FIRStruct)(*self - other);
 } EndFunc()
-BeginOp(FIR_Operator_Neg, 0, "Operator Neg", "The Negation operator for this struct.") {
+BeginOp(FIR_Operator_Neg, 0, "Operator Neg", "The Negation operator for this struct.", 2) {
 	OutVal(0, RStruct<FVector2D>, result, "Result", "The resulting vector of the vector negation")
 	Body()
 	result = (FIRStruct)(-*self);
 } EndFunc()
-BeginOp(FIR_Operator_Mul, 0, "Scalar Product", "") {
+BeginOp(FIR_Operator_Mul, 0, "Scalar Product", "", 2) {
 	InVal(0, RStruct<FVector2D>, other, "Other", "The other vector to calculate the scalar product with.")
 	OutVal(1, RFloat, result, "Result", "The resulting scalar product.")
 	Body()
 	result = (FIRStruct)(*self * other);
 } EndFunc()
-BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "") {
+BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "", 2) {
 	InVal(0, RFloat, factor, "Factor", "The factor with which this vector should be scaled with.")
 	OutVal(1, RStruct<FVector2D>, result, "Result", "The resulting scaled vector.")
 	Body()
@@ -187,45 +187,45 @@ BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "") {
 EndStruct()
 
 BeginStructConstructable(FVector, "Vector", "Vector", "Contains three cordinates (X, Y, Z) to describe a position or movement vector in 3D Space")
-BeginProp(RFloat, x, "X", "The X coordinate component") {
+BeginProp(RFloat, x, "X", "The X coordinate component", 2) {
 	FIRReturn self->X;
 } PropSet() {
 	self->X = Val;
 } EndProp()
-BeginProp(RFloat, y, "Y", "The Y coordinate component") {
+BeginProp(RFloat, y, "Y", "The Y coordinate component", 2) {
 	FIRReturn self->Y;
 } PropSet() {
 	self->Y = Val;
 } EndProp()
-BeginProp(RFloat, z, "Z", "The Z coordinate component") {
+BeginProp(RFloat, z, "Z", "The Z coordinate component", 2) {
 	FIRReturn self->Z;
 } PropSet() {
 	self->Z = Val;
 } EndProp()
-BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.") {
+BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.", 2) {
 	InVal(0, RStruct<FVector>, other, "Other", "The other vector that should be added to this vector")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting vector of the vector addition")
 	Body()
 	result = (FIRStruct)(*self + other);
 } EndFunc()
-BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.") {
+BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.", 2) {
 	InVal(0, RStruct<FVector>, other, "Other", "The other vector that should be subtracted from this vector")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting vector of the vector subtraction")
 	Body()
 	result = (FIRStruct)(*self - other);
 } EndFunc()
-BeginOp(FIR_Operator_Neg, 0, "Operator Neg", "The Negation operator for this struct.") {
+BeginOp(FIR_Operator_Neg, 0, "Operator Neg", "The Negation operator for this struct.", 2) {
 	OutVal(0, RStruct<FVector>, result, "Result", "The resulting vector of the vector negation")
 	Body()
 	result = (FIRStruct)(-*self);
 } EndFunc()
-BeginOp(FIR_Operator_Mul, 0, "Operator Mul", "") {
+BeginOp(FIR_Operator_Mul, 0, "Operator Mul", "", 2) {
 	InVal(0, RStruct<FVector>, other, "Other", "The multiplication (*) operator for this struct. (Each component gets multiplied with the component of the other vector)")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting vector of the vector multiplication.")
 	Body()
 	result = (FIRStruct)(*self * other);
 } EndFunc()
-BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "") {
+BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "", 2) {
 	InVal(0, RFloat, factor, "Factor", "The factor with which this vector should be scaled with.")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting scaled vector.")
 	Body()
@@ -234,28 +234,28 @@ BeginOp(FIR_Operator_Mul, 1, "Vector Factor Scaling", "") {
 EndStruct()
 
 BeginStructConstructable(FRotator, "Rotator", "Rotator", "Contains rotation information about a object in 3D spaces using 3 rotation axis in a gimble.")
-BeginProp(RFloat, pitch, "Pitch", "The pitch component") {
+BeginProp(RFloat, pitch, "Pitch", "The pitch component", 2) {
 	FIRReturn self->Pitch;
 } PropSet() {
 	self->Pitch = Val;
 } EndProp()
-BeginProp(RFloat, yaw, "Yaw", "The yaw component") {
+BeginProp(RFloat, yaw, "Yaw", "The yaw component", 2) {
 	FIRReturn self->Yaw;
 } PropSet() {
 	self->Yaw = Val;
 } EndProp()
-BeginProp(RFloat, roll, "Roll", "The roll component") {
+BeginProp(RFloat, roll, "Roll", "The roll component", 2) {
 	FIRReturn self->Roll;
 } PropSet() {
 	self->Roll = Val;
 } EndProp()
-BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.") {
+BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.", 2) {
 	InVal(0, RStruct<FRotator>, other, "Other", "The other rotator that should be added to this rotator")
 	OutVal(1, RStruct<FRotator>, result, "Result", "The resulting rotator of the vector addition")
 	Body()
 	result = (FIRStruct)(*self + other);
 } EndFunc()
-BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.") {
+BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.", 2) {
 	InVal(0, RStruct<FRotator>, other, "Other", "The other rotator that should be subtracted from this rotator")
 	OutVal(1, RStruct<FRotator>, result, "Result", "The resulting rotator of the vector subtraction")
 	Body()
@@ -264,50 +264,50 @@ BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for t
 EndStruct()
 
 BeginStructConstructable(FLinearColor, "Color", "Color", "A structure that holds a rgba color value")
-BeginProp(RFloat, r, "Red", "The red portion of the color.") {
+BeginProp(RFloat, r, "Red", "The red portion of the color.", 2) {
 	FIRReturn (FIRFloat) self->R;
 } PropSet() {
 	self->R = Val;
 } EndProp()
-BeginProp(RFloat, g, "Green", "The green portion of the color.") {
+BeginProp(RFloat, g, "Green", "The green portion of the color.", 2) {
 	FIRReturn (FIRFloat) self->G;
 } PropSet() {
 	self->G = Val;
 } EndProp()
-BeginProp(RFloat, b, "Blue", "The blue portion of the color.") {
+BeginProp(RFloat, b, "Blue", "The blue portion of the color.", 2) {
 	FIRReturn (FIRFloat) self->B;
 } PropSet() {
 	self->B = Val;
 } EndProp()
-BeginProp(RFloat, a, "Alpha", "The alpha (opacity) portion of the color.") {
+BeginProp(RFloat, a, "Alpha", "The alpha (opacity) portion of the color.", 2) {
 	FIRReturn (FIRFloat) self->A;
 } PropSet() {
 	self->A = Val;
 } EndProp()
-BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.") {
+BeginOp(FIR_Operator_Add, 0, "Operator Add", "The addition (+) operator for this struct.", 2) {
 	InVal(0, RStruct<FLinearColor>, other, "Other", "The other color that should be added to this color")
 	OutVal(1, RStruct<FLinearColor>, result, "Result", "The resulting color of the color addition")
 	Body()
 	result = (FIRStruct)(*self + other);
 } EndFunc()
-BeginOp(FIR_Operator_Neg, 1, "Operator Neg", "The Negation operator for this struct. Does NOT make the color negative. Calculates 1 - this.") {
+BeginOp(FIR_Operator_Neg, 1, "Operator Neg", "The Negation operator for this struct. Does NOT make the color negative. Calculates 1 - this.", 2) {
 	OutVal(0, RStruct<FLinearColor>, result, "Result", "The resulting color of the color addition")
 	Body()
 	result = (FIRStruct)(FLinearColor::White - *self);
 } EndFunc()
-BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.") {
+BeginOp(FIR_Operator_Sub, 0, "Operator Sub", "The subtraction (-) operator for this struct.", 2) {
 	InVal(0, RStruct<FLinearColor>, other, "Other", "The other color that should be subtracted from this color")
 	OutVal(1, RStruct<FLinearColor>, result, "Result", "The resulting color of the color subtraction")
 	Body()
 	result = (FIRStruct)(*self - other);
 } EndFunc()
-BeginOp(FIR_Operator_Mul, 1, "Color Factor Scaling", "") {
+BeginOp(FIR_Operator_Mul, 1, "Color Factor Scaling", "", 2) {
 	InVal(0, RFloat, factor, "Factor", "The factor with which this color should be scaled with.")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting scaled color.")
 	Body()
 	result = (FIRStruct)(*self * factor);
 } EndFunc()
-BeginOp(FIR_Operator_Div, 1, "Color Inverse Factor Scaling", "") {
+BeginOp(FIR_Operator_Div, 1, "Color Inverse Factor Scaling", "", 2) {
 	InVal(0, RFloat, factor, "Factor", "The factor with which this color should be scaled inversly with.")
 	OutVal(1, RStruct<FVector>, result, "Result", "The resulting inverse scaled color.")
 	Body()
@@ -316,22 +316,22 @@ BeginOp(FIR_Operator_Div, 1, "Color Inverse Factor Scaling", "") {
 EndStruct()
 
 BeginStructConstructable(FMargin, "Margin", "Margin", "A struct containing four floats that describe a margin around a box (like a 9-patch).")
-BeginProp(RFloat, left, "Left", "The left edge of the rectangle.") {
+BeginProp(RFloat, left, "Left", "The left edge of the rectangle.", 2) {
 	FIRReturn FIRFloat(self->Left);
 } PropSet() {
 	self->Left = Val;
 } EndProp()
-BeginProp(RFloat, right, "Right", "The right edge of the rectangle.") {
+BeginProp(RFloat, right, "Right", "The right edge of the rectangle.", 2) {
 	FIRReturn FIRFloat(self->Right);
 } PropSet() {
 	self->Right = Val;
 } EndProp()
-BeginProp(RFloat, top, "Top", "The top edge of the rectangle.") {
+BeginProp(RFloat, top, "Top", "The top edge of the rectangle.", 2) {
 	FIRReturn FIRFloat(self->Top);
 } PropSet() {
 	self->Top = Val;
 } EndProp()
-BeginProp(RFloat, bottom, "Bottom", "The bottom edge of the rectangle.") {
+BeginProp(RFloat, bottom, "Bottom", "The bottom edge of the rectangle.", 2) {
 	FIRReturn FIRFloat(self->Left);
 } PropSet() {
 	self->Bottom = Val;
@@ -339,22 +339,22 @@ BeginProp(RFloat, bottom, "Bottom", "The bottom edge of the rectangle.") {
 EndStruct()
 
 BeginStructConstructable(FVector4, "Vector4", "Vector4", "A Vector containing four values.")
-BeginProp(RFloat, x, "X", "The first value in the Vector4.") {
+BeginProp(RFloat, x, "X", "The first value in the Vector4.", 2) {
 	FIRReturn self->X;
 } PropSet() {
 	self->X = Val;
 } EndProp()
-BeginProp(RFloat, y, "Y", "The second value in the Vector4.") {
+BeginProp(RFloat, y, "Y", "The second value in the Vector4.", 2) {
 	FIRReturn self->Y;
 } PropSet() {
 	self->Y = Val;
 } EndProp()
-BeginProp(RFloat, z, "Z", "The third value in the Vector4.") {
+BeginProp(RFloat, z, "Z", "The third value in the Vector4.", 2) {
 	FIRReturn self->Z;
 } PropSet() {
 	self->Z = Val;
 } EndProp()
-BeginProp(RFloat, w, "W", "The fourth value in the Vector4.") {
+BeginProp(RFloat, w, "W", "The fourth value in the Vector4.", 2) {
 	FIRReturn self->W;
 } PropSet() {
 	self->W = Val;

--- a/Source/FicsItReflection/Public/Reflection/FIRStruct.h
+++ b/Source/FicsItReflection/Public/Reflection/FIRStruct.h
@@ -100,13 +100,13 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	virtual void InvalidateCache() {
-		FScopeLock nameCacheLock(&NameCacheMutex);
+		FWriteScopeLock nameCacheLock(NameCacheMutex);
 		Name2Property.Empty();
 		Name2Function.Empty();
 	}
 
 private:
-	FCriticalSection NameCacheMutex;
+	FRWLock NameCacheMutex;
 	TMap<FString, TArray<UFIRProperty*>> Name2Property;
 	TMap<FString, TArray<UFIRFunction*>> Name2Function;
 };


### PR DESCRIPTION
Also changed `ScopedLock` to `RWLock`; it didn't improve performance much, but I made this change during investigation, and it made sense to include it as well.